### PR TITLE
Experiment: Add RAVine-inspired Evaluation Framework

### DIFF
--- a/experiments/ravine_evaluator/README.md
+++ b/experiments/ravine_evaluator/README.md
@@ -1,0 +1,40 @@
+# VQASynth Evaluation Framework
+
+This experimental evaluation script is inspired by the structured, metric-driven evaluation methodology of the [RAVine](https://github.com/SwordFaith/RAVine) project. It provides a simple way to benchmark the performance of models trained with VQASynth, focusing on the key capability of quantitative spatial reasoning (i.e., distance estimation).
+
+## Usage
+
+The script `process_evaluation.py` calculates the Mean Absolute Error (MAE) and other statistics between model-generated answers and ground-truth answers. It expects both inputs to be in JSONL format.
+
+### Input File Format
+
+The script requires two files: one for predictions and one for ground truth. Both should be JSONL files, where each line is a JSON object.
+
+Each JSON object must contain:
+1.  A unique identifier key (e.g., `"image_id": "warehouse_sample_2.jpeg"`) to match predictions with ground truth.
+2.  An `"answer"` key containing the text to be evaluated (e.g., `"answer": "The man is about 2 feet away."`).
+
+The script automatically parses numerical values and common units (m, cm, ft) from the answer strings.
+
+**Example `predictions.jsonl`:**
+```json
+{"image_id": "img_001.jpg", "question": "...", "answer": "<think>...</think> <answer>The person is approximately 1.5 meters from the table.</answer>"}
+```
+
+**Example `ground_truth.jsonl`:**
+```json
+{"image_id": "img_001.jpg", "question": "...", "answer": "1.4 meters"}
+```
+
+### Running the Evaluation
+
+To run the evaluation, execute the script from the repository root:
+
+```bash
+python experiments/ravine_evaluator/process_evaluation.py \
+    --predictions /path/to/your/predictions.jsonl \
+    --ground-truth /path/to/your/ground_truth.jsonl \
+    --id-key image_id
+```
+
+The script will print a report with the evaluation metrics to the console.

--- a/experiments/ravine_evaluator/process_evaluation.py
+++ b/experiments/ravine_evaluator/process_evaluation.py
@@ -1,0 +1,106 @@
+import argparse
+import json
+import re
+import numpy as np
+from typing import Dict, List, Optional
+
+def convert_to_meters(value: float, unit: str) -> float:
+    """Converts a distance to meters."""
+    unit = unit.lower()
+    if unit in ["meter", "meters", "m"]:
+        return value
+    elif unit in ["centimeter", "centimeters", "cm"]:
+        return value / 100.0
+    elif unit in ["foot", "feet", "ft"]:
+        return value * 0.3048
+    # Assume meters if unit is unknown or not specified
+    return value
+
+def parse_distance(text: str) -> Optional[float]:
+    """
+    Parses a string to find a numerical distance and converts it to meters.
+    Example: "The distance is 2.5 feet." -> 0.762
+    """
+    # Regex to find a number followed by an optional common distance unit.
+    match = re.search(r'(\d+\.?\d*)\s*(meters?|m|centimeters?|cm|feet|foot|ft)\b', text, re.IGNORECASE)
+    
+    if match:
+        value = float(match.group(1))
+        unit = match.group(2)
+        return convert_to_meters(value, unit)
+        
+    # Fallback for just a number, assuming the canonical unit is meters.
+    match = re.search(r'(\d+\.?\d*)', text)
+    if match:
+        return float(match.group(1))
+        
+    return None
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate VQA model predictions based on RAVine principles.")
+    parser.add_argument("--predictions", type=str, required=True, help="Path to the JSONL file with model predictions.")
+    parser.add_argument("--ground-truth", type=str, required=True, help="Path to the JSONL file with ground truth answers.")
+    parser.add_argument("--id-key", type=str, default="image_id", help="The key used to match predictions and ground truth.")
+    
+    args = parser.parse_args()
+
+    # Load ground truth into a dictionary for easy lookup
+    ground_truth_map: Dict[str, Dict] = {}
+    with open(args.ground_truth, 'r') as f:
+        for line in f:
+            data = json.loads(line)
+            if args.id_key in data:
+                ground_truth_map[data[args.id_key]] = data
+
+    predictions: List[Dict] = []
+    with open(args.predictions, 'r') as f:
+        for line in f:
+            predictions.append(json.loads(line))
+
+    errors = []
+    parsed_count = 0
+    total_count = 0
+
+    for pred in predictions:
+        total_count += 1
+        pred_id = pred.get(args.id_key)
+        if not pred_id or pred_id not in ground_truth_map:
+            continue
+
+        gt = ground_truth_map[pred_id]
+        
+        # Extract text from the <answer> tag if present, otherwise use the whole string
+        pred_answer = pred.get('answer', '')
+        if '<answer>' in pred_answer:
+            pred_answer = pred_answer.split('<answer>')[-1].strip()
+
+        gt_answer = gt.get('answer', '')
+
+        pred_dist = parse_distance(pred_answer)
+        gt_dist = parse_distance(gt_answer)
+
+        if pred_dist is not None and gt_dist is not None:
+            errors.append(abs(pred_dist - gt_dist))
+            parsed_count += 1
+
+    print("--- VQASynth Evaluation Report (inspired by RAVine) ---")
+    if total_count > 0:
+        print(f"Processed {total_count} predictions.")
+        print(f"Successfully parsed quantitative distances for {parsed_count} pairs.")
+    
+    if errors:
+        mae = np.mean(errors)
+        std_err = np.std(errors)
+        median_ae = np.median(errors)
+        
+        print("\nQuantitative Distance Estimation Metrics (in meters):")
+        print(f"  Mean Absolute Error (MAE): {mae:.4f}")
+        print(f"  Median Absolute Error:     {median_ae:.4f}")
+        print(f"  Standard Deviation of AE:  {std_err:.4f}")
+    else:
+        print("\nCould not compute metrics. No valid quantitative distance pairs found.")
+        print("Please ensure your prediction and ground truth files contain parseable distances (e.g., '5 meters', '1.2 ft').")
+    print("---------------------------------------------------------")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a minimal, testable experiment to integrate an evaluation framework into VQASynth, inspired by the SOURCE repo, RAVine. VQASynth excels at generating synthetic data to train spatial reasoning models but currently lacks a standardized, in-repo tool to benchmark the performance of these models. Claims like 'most accurate distance estimates' rely on offline or ad-hoc evaluation.

The RAVine project provides a comprehensive, reality-aligned evaluation framework for agentic LLMs, focusing on structured metrics like precision, recall, and completeness against ground-truth 'nuggets'. We can adapt this core principle—comparing generated outputs against a ground truth using clear metrics—to the spatial VQA context of VQASynth.

This experiment adds a self-contained evaluation script in a new `experiments/ravine_evaluator` directory. The initial script focuses on a key capability trained by VQASynth: quantitative distance estimation. It parses numerical distances from model predictions and ground-truth answers, calculates metrics like Mean Absolute Error (MAE), and provides a simple report. This creates a foundation for more rigorous, automated, and reproducible model evaluation within the VQASynth project.


### Test Strategy
- Create a sample `predictions.jsonl` file with model outputs (containing quantitative distance answers) and a corresponding `ground_truth.jsonl`.
- Run the evaluation script from the repo root: `python experiments/ravine_evaluator/process_evaluation.py --predictions predictions.jsonl --ground-truth ground_truth.jsonl`.
- Verify that the script runs without errors and outputs a console report with the calculated Mean Absolute Error (MAE) for the sample data.


### Success Criteria
- The evaluation script successfully parses numerical values and units from model-generated answers and ground truth strings.
- The script correctly calculates and reports Mean Absolute Error for quantitative distance estimation tasks.
- The process is clearly documented in the new README, enabling users to benchmark models trained with VQASynth.


**Labels:** experiment, evaluation