### PR TITLE
Feat: Add Ravine Evaluator using SADA for accelerated synthesis

### DIFF
--- a/experiments/ravine_evaluator/README.md
+++ b/experiments/ravine_evaluator/README.md
@@ -1,0 +1,46 @@
+# Ravine Evaluator
+
+This directory contains an experiment to generate synthetic evaluation data for VQASynth-trained models. The goal is to create a fast, reproducible way to generate images with known spatial ground truth, which can be used to benchmark the spatial reasoning capabilities of Vision-Language Models.
+
+This experiment integrates `SADA` (Stability-guided Adaptive Diffusion Acceleration) to accelerate the image generation process using the `FLUX.1-dev` diffusion model from Hugging Face.
+
+## How it Works
+
+The `process_evaluation.py` script performs the following steps:
+1.  Generates an image using the standard `diffusers` pipeline for a baseline measurement.
+2.  Applies the `SADA` patch to a new pipeline instance.
+3.  Generates the same image using the SADA-accelerated pipeline.
+4.  Compares the generation time, calculates the speedup, and measures the visual similarity using the LPIPS metric.
+5.  Saves a side-by-side comparison image `ravine_comparison.png`.
+
+## Usage
+
+### 1. Installation
+
+Ensure you have a Python environment with PyTorch and CUDA support. Then, install the required packages:
+
+```bash
+# Install core dependencies for the script
+pip install diffusers transformers accelerate torch torchvision lpips
+
+# Install SADA directly from the source repository
+pip install git+https://github.com/Ting-Justin-Jiang/sada-icml.git
+```
+
+### 2. Run the Experiment
+
+Execute the script from the repository root:
+
+```bash
+python experiments/ravine_evaluator/process_evaluation.py
+```
+
+### 3. Check the Output
+
+The script will print the following to the console:
+-   Baseline generation time.
+-   SADA-accelerated generation time.
+-   The calculated speedup factor (e.g., `Speedup: 1.85x`).
+-   The LPIPS distance, where a lower score indicates higher similarity to the baseline.
+
+Additionally, an image file named `ravine_comparison.png` will be created in the current directory, allowing for a visual comparison between the baseline (left) and SADA-accelerated (right) images.

--- a/experiments/ravine_evaluator/process_evaluation.py
+++ b/experiments/ravine_evaluator/process_evaluation.py
@@ -1,0 +1,115 @@
+import time
+import torch
+import lpips
+from diffusers import FluxPipeline
+from torchvision.utils import save_image
+import torchvision.transforms as T
+
+# Import the SADA patch module
+from sada import patch
+
+def set_random_seed(seed):
+    """Sets the random seed for reproducibility."""
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+def main():
+    """
+    Main function to run the evaluation generation experiment.
+    Generates an image with a baseline diffusion pipeline and an SADA-accelerated one,
+    then compares their speed and visual similarity.
+    """
+    # --- Configuration ---
+    MODEL_ID = "black-forest-labs/FLUX.1-dev"
+    PROMPT = "A high-resolution photo of a red cube directly on top of a large blue sphere. They are on a plain white surface in a brightly lit studio."
+    SEED = 42
+    HEIGHT = 1024
+    WIDTH = 1024
+    NUM_INFERENCE_STEPS = 50
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+    DTYPE = torch.bfloat16
+
+    set_random_seed(SEED)
+    print("--- Ravine Evaluator: SADA Acceleration Experiment ---")
+    print(f"Using model: {MODEL_ID}")
+    print(f"Using device: {DEVICE}")
+
+    # --- Baseline Generation ---
+    print("\n1. Running baseline generation...")
+    baseline_pipe = FluxPipeline.from_pretrained(MODEL_ID, torch_dtype=DTYPE).to(DEVICE)
+    
+    # Warmup
+    _ = baseline_pipe(PROMPT, height=HEIGHT, width=WIDTH, num_inference_steps=2, output_type='pt').images
+    
+    start_time = time.time()
+    set_random_seed(SEED)
+    baseline_output = baseline_pipe(
+        PROMPT,
+        height=HEIGHT,
+        width=WIDTH,
+        guidance_scale=3.5,
+        num_inference_steps=NUM_INFERENCE_STEPS,
+        output_type='pt'
+    ).images
+    baseline_time = time.time() - start_time
+    print(f"Baseline generation took: {baseline_time:.2f} seconds")
+
+    del baseline_pipe
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # --- SADA-accelerated Generation ---
+    print("\n2. Running SADA-accelerated generation...")
+    sada_pipe = FluxPipeline.from_pretrained(MODEL_ID, torch_dtype=DTYPE).to(DEVICE)
+    
+    # Apply the SADA patch
+    patch.apply_patch(
+        sada_pipe,
+        max_downsample=0,
+        acc_range=(10, 47),
+        latent_size=(HEIGHT // 16, WIDTH // 16),
+        lagrange_int=4,
+        lagrange_step=20,
+        lagrange_term=3,
+        max_fix=0,
+        max_interval=4
+    )
+
+    # Warmup
+    _ = sada_pipe(PROMPT, height=HEIGHT, width=WIDTH, num_inference_steps=2, output_type='pt').images
+    patch.reset_cache(sada_pipe)
+
+    start_time = time.time()
+    set_random_seed(SEED)
+    sada_output = sada_pipe(
+        PROMPT,
+        height=HEIGHT,
+        width=WIDTH,
+        guidance_scale=3.5,
+        num_inference_steps=NUM_INFERENCE_STEPS,
+        output_type='pt'
+    ).images
+    sada_time = time.time() - start_time
+    print(f"SADA generation took: {sada_time:.2f} seconds")
+
+    # --- Analysis ---
+    print("\n3. Analyzing results...")
+    speedup = baseline_time / sada_time
+    print(f"Speedup: {speedup:.2f}x")
+
+    save_image([baseline_output[0], sada_output[0]], "ravine_comparison.png")
+    print("Saved comparison image to 'ravine_comparison.png'")
+
+    # Calculate LPIPS
+    loss_fn_alex = lpips.LPIPS(net='alex').to(DEVICE)
+    # Normalize images for LPIPS
+    transform = T.Compose([T.Normalize((0.5,), (0.5,))])
+    baseline_tensor = transform(baseline_output[0]).to(DEVICE)
+    sada_tensor = transform(sada_output[0]).to(DEVICE)
+    
+    lpips_distance = loss_fn_alex(baseline_tensor.unsqueeze(0), sada_tensor.unsqueeze(0))
+    print(f"LPIPS distance (lower is better): {lpips_distance.item():.4f}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
VQASynth improves spatial reasoning in VLMs using datasets derived from real-world images. Evaluating these models often relies on existing benchmarks or qualitative assessments. A key challenge is creating controlled evaluation sets where spatial ground truth is unambiguously known.

The SADA repository introduces a training-free method to accelerate inference in diffusion models, making large-scale synthetic data generation more feasible. By integrating SADA, we can efficiently create novel evaluation benchmarks consisting of images with precise, programmatically defined spatial relationships (e.g., "a red cube on top of a blue cylinder").

This experiment proposes adding a new, self-contained evaluation script that leverages a `diffusers`-based model (FLUX), accelerated by SADA, to generate a synthetic image dataset. This allows for a fast, reproducible, and controlled evaluation of the spatial reasoning capabilities of models trained with VQASynth, complementing existing evaluation strategies by testing them on novel, out-of-distribution synthetic scenes.


### Test Strategy
- Create and checkout the new branch: `git checkout -b experiment/sada-ravine-evaluator`.
- Install dependencies for the experiment: `pip install diffusers transformers accelerate lpips torch torchvision`.
- Install the SADA library from its GitHub repository: `pip install git+https://github.com/Ting-Justin-Jiang/sada-icml.git`.
- Run the evaluation script from the repository root: `python experiments/ravine_evaluator/process_evaluation.py`.
- Observe the console output for timing, speedup factor, and LPIPS score.
- Inspect the generated `ravine_comparison.png` file to visually compare the baseline and SADA-accelerated images.


### Success Criteria
- The script executes completely without any errors.
- The SADA-accelerated generation shows a speedup of >1.5x compared to the baseline.
- The LPIPS score between the baseline and accelerated image is less than 0.1, indicating high visual fidelity.
- The `ravine_comparison.png` image shows that both generated images accurately reflect the spatial arrangement described in the prompt.


**Labels:** experiment, evaluation