### PR TITLE
Experiment: Generate "Unachievable" Spatial Questions

### DIFF
--- a/experiments/mirage_unachievable_generator/run.py
+++ b/experiments/mirage_unachievable_generator/run.py
@@ -1,0 +1,106 @@
+import json
+import argparse
+import os
+from pathlib import Path
+
+# Placeholder for a function that would analyze scene data to find ambiguities
+def find_unachievable_scenarios(scene_data):
+    """
+    Analyzes scene data to find objects that are unsuitable for reliable spatial questions.
+    
+    For this experiment, we'll define "unachievable" as any object that is heavily
+    occluded or is smaller than a certain pixel threshold.
+
+    Args:
+        scene_data (dict): A dictionary containing object masks, bboxes, etc.
+
+    Returns:
+        list: A list of object pairs where a spatial relationship is ambiguous.
+    """
+    unachievable_pairs = []
+    objects = scene_data.get("objects", [])
+    
+    if len(objects) < 2:
+        return []
+
+    # Simplified logic: find one heavily occluded object and pair it with a visible one.
+    # A real implementation would use mask intersection over union (IoU) for occlusion.
+    occluded_obj = None
+    visible_obj = None
+    for obj in objects:
+        if obj.get("occlusion_score", 0) > 0.7 and not occluded_obj:
+            occluded_obj = obj
+        elif obj.get("occlusion_score", 0) < 0.2 and not visible_obj:
+            visible_obj = obj
+
+    if occluded_obj and visible_obj:
+        unachievable_pairs.append((occluded_obj, visible_obj))
+        
+    return unachievable_pairs
+
+
+def generate_unachievable_qa(scenarios):
+    """
+    Generates question-answer pairs based on unachievable scenarios.
+    
+    Inspired by MIRAGE-Bench, the goal is to create questions that test a model's
+    ability to recognize ambiguity, rather than hallucinating an answer.
+    """
+    vqa_pairs = []
+    for obj1, obj2 in scenarios:
+        question = f"How far is the {obj1['label']} from the {obj2['label']}?"
+        answer = f"I cannot accurately determine the distance, as the {obj1['label']} appears to be heavily occluded in the image."
+        
+        vqa_pairs.append({
+            "question": question,
+            "answer": answer,
+            "reasoning_type": "unachievable-occlusion"
+        })
+    return vqa_pairs
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate 'unachievable' VQA pairs inspired by MIRAGE-Bench.")
+    parser.add_argument("--input_dir", type=str, required=True, help="Directory with scene data JSON files from VQASynth.")
+    parser.add_argument("--output_dir", type=str, required=True, help="Directory to save the new VQA pairs.")
+    args = parser.parse_args()
+
+    input_path = Path(args.input_dir)
+    output_path = Path(args.output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    print(f"Scanning for scene data in: {input_path}")
+    
+    # In a real run, we would iterate through actual files.
+    # For this testable example, we use a mock data structure.
+    for i in range(3): # Mock processing 3 images
+        scene_file_name = f"scene_{i}.json"
+        print(f"Processing {scene_file_name}...")
+
+        # This is a mock structure of what VQASynth might produce.
+        # The occlusion scores are varied to trigger the logic.
+        mock_scene_data = {
+            "image_id": f"scene_{i}",
+            "objects": [
+                {"id": 1, "label": "red forklift", "bbox": [10, 50, 80, 200], "occlusion_score": 0.1 * i},
+                {"id": 2, "label": "stack of boxes", "bbox": [100, 40, 250, 220], "occlusion_score": 0.8 - (0.1 * i)},
+                {"id": 3, "label": "wooden pallet", "bbox": [5, 210, 300, 250], "occlusion_score": 0.3}
+            ]
+        }
+
+        unachievable_scenarios = find_unachievable_scenarios(mock_scene_data)
+        
+        if not unachievable_scenarios:
+            print(f"No unachievable scenarios found in {scene_file_name}.")
+            continue
+            
+        new_vqa_data = generate_unachievable_qa(unachievable_scenarios)
+        
+        output_file = output_path / f"{mock_scene_data['image_id']}_unachievable_vqa.json"
+        with open(output_file, 'w') as f:
+            json.dump(new_vqa_data, f, indent=2)
+        print(f"Saved {len(new_vqa_data)} new QA pairs to {output_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The SOURCE repo, MIRAGE-Bench, introduces a framework for evaluating hallucinations in LLM agents. A key concept from its taxonomy is the 'unachievable' task, where an agent is faced with an impossible goal. This forces an evaluation of whether the agent hallucinates a solution or correctly identifies the impossibility. The `verify_all.sh` script explicitly defines 'unachievable' as a scenario type, demonstrating its importance in the benchmark.

This experiment integrates this concept into the TARGET repo, VQASynth, which generates spatial VQA datasets. Currently, VQASynth focuses on generating answerable questions from derived 3D scene data. We propose adding a new experimental stage that identifies ambiguous or 'unachievable' scenarios within an image—such as heavily occluded objects—and generates corresponding question-answer pairs. The goal is to create a more robust training set that teaches VLMs to recognize and articulate uncertainty (e.g., answering "I cannot determine...") instead of hallucinating spatial relationships. This directly applies MIRAGE-Bench's evaluation principles to improve the quality and safety of the data generation pipeline.


### Test Strategy
- Prepare a sample directory of VQASynth intermediate scene data (JSON files with object labels, bounding boxes, and mock occlusion scores).
- Run the `experiments/mirage_unachievable_generator/run.py` script, pointing to the prepared input directory and an empty output directory.
- Verify that the script creates new JSON files in the output directory for scenes with qualifying occlusion scores.
- Manually inspect the generated QA pairs to ensure the questions correspond to the occluded objects and the answers are refusal-style, as intended.


### Success Criteria
- The script successfully runs and generates 'unachievable' QA pairs for input scenes that meet the ambiguity criteria (e.g., high occlusion score).
- A manual review of 20 generated QA pairs shows that >90% are logically sound, where the question is validly unanswerable and the provided answer is a reasonable refusal.
- The generated data format is compatible with the downstream training stages of the VQASynth pipeline.


**Labels:** experiment

---
**Source:** https://github.com/sunblaze-ucb/mirage-bench
**Evidence:**
- `README.md`
- `verify_all.sh`