### PR TITLE
feat: Integrate EDGE-GRPO for Spatial Reasoning RL Tuning

### DIFF
--- a/experiments/edge_grpo_tuning/run.py
+++ b/experiments/edge_grpo_tuning/run.py
@@ -1,0 +1,125 @@
+# A minimal implementation of EDGE-GRPO logic
+# for fine-tuning a VLM on spatial reasoning tasks.
+# Based on concepts from Zhang et al., 2025 (EDGE-GRPO)
+# and the structure of HuggingFace TRL.
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from trl import DPOTrainer, DPOConfig
+from datasets import Dataset
+
+# --- Core EDGE-GRPO Logic ---
+# In a real scenario, this would be a more robust trainer class.
+# Here, we override the loss function of DPOTrainer for demonstration.
+class EdgeGRPOTrainer(DPOTrainer):
+    def __init__(self, *args, grpo_alpha: float = 0.1, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.grpo_alpha = grpo_alpha
+        print(f"Initialized EdgeGRPOTrainer with alpha={self.grpo_alpha}")
+
+    def get_batch_loss_metrics(self, model, batch, train_eval="train"):
+        """
+        Computes the EDGE-GRPO loss.
+        This overrides the standard DPO loss calculation.
+        """
+        metrics = {}
+        
+        # 1. Get Log Probs from Policy and Reference models
+        # This is handled by the parent DPO trainer's method
+        policy_chosen_logps, policy_rejected_logps, policy_chosen_logits, _ = self.concatenated_forward(model, batch)
+        with torch.no_grad():
+            ref_chosen_logps, ref_rejected_logps, _, _ = self.concatenated_forward(self.ref_model, batch)
+
+        # 2. Define Rewards
+        # For this minimal experiment, we assume a fixed reward structure,
+        # where the "chosen" response has a reward of 1 and "rejected" has 0.
+        # In a real VQA task, this would come from a reward model or a correctness check.
+        # This aligns with GRPO's group-based sparse rewards.
+        reward_chosen = torch.tensor(1.0, device=model.device)
+        reward_rejected = torch.tensor(0.0, device=model.device)
+
+        # 3. Calculate Advantage (A_hat)
+        # Advantage is the difference in rewards. In GRPO, it's relative.
+        # A_hat = r_chosen - r_rejected
+        advantage = reward_chosen - reward_rejected
+
+        # 4. Calculate Policy Entropy (H(pi_theta))
+        # Entropy is calculated for the chosen (higher-reward) response.
+        # H(p) = - sum(p(x) * log(p(x)))
+        probs = F.softmax(policy_chosen_logits, dim=-1)
+        log_probs = F.log_softmax(policy_chosen_logits, dim=-1)
+        # We average entropy over the sequence length and batch
+        entropy = -torch.sum(probs * log_probs, dim=-1).mean()
+
+        # 5. --- EDGE-GRPO Modification ---
+        # Augment advantage with entropy bonus: A_hat_edge = A_hat + alpha * H(pi_theta)
+        # This is the core idea from the SOURCE repo to prevent advantage collapse.
+        edge_advantage = advantage + self.grpo_alpha * entropy
+
+        # 6. Calculate Log Prob Ratios
+        pi_logratios = policy_chosen_logps - policy_rejected_logps
+        ref_logratios = ref_chosen_logps - ref_rejected_logps
+
+        # 7. Calculate GRPO Loss
+        # Similar to DPO loss, but using the advantage term.
+        # loss = -log_sigmoid(beta * (pi_logratios - ref_logratios) * advantage)
+        # We use our edge_advantage here.
+        logits = pi_logratios - ref_logratios
+        loss = -F.logsigmoid(self.beta * logits * edge_advantage).mean()
+
+        # Store metrics
+        metrics["loss"] = loss.item()
+        metrics["rewards/chosen"] = reward_chosen.mean().cpu()
+        metrics["rewards/rejected"] = reward_rejected.mean().cpu()
+        metrics["rewards/advantage"] = advantage.mean().cpu()
+        metrics["rewards/edge_advantage"] = edge_advantage.mean().cpu()
+        metrics["policy/entropy"] = entropy.item()
+
+        return loss, metrics
+
+# --- Experiment Setup ---
+def run_experiment():
+    # 1. Model and Tokenizer (Using a small, fast model for demonstration)
+    model_name = "gpt2"
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    # 2. Dummy VQA-Synth Dataset
+    # In a real run, this would be loaded from the VQA-Synth pipeline.
+    # It contains a prompt, a good answer ('chosen'), and a bad answer ('rejected').
+    data = {
+        'prompt': ["USER: In the image, is the red chair to the left of the blue table? ASSISTANT:", "USER: How far is the book from the lamp? ASSISTANT:"],
+        'chosen': ["I think... The red chair is indeed to the left of the blue table. The final answer is yes.", "I think... The book is about 2 feet away from the lamp. The final answer is 2 feet."],
+        'rejected': ["I think... The red chair is to the right of the blue table. The final answer is no.", "I think... The book is very close to the lamp. The final answer is close."]
+    }
+    dataset = Dataset.from_dict(data)
+
+    # 3. DPO/GRPO Configuration
+    config = DPOConfig(
+        output_dir="./edge_grpo_test_output",
+        beta=0.1, # DPO temperature
+        learning_rate=1e-5,
+        per_device_train_batch_size=1,
+        num_train_epochs=1,
+        logging_steps=1,
+        save_strategy="no",
+    )
+
+    # 4. Initialize and Run Trainer
+    trainer = EdgeGRPOTrainer(
+        model=model,
+        ref_model=None, # DPO trainer will create a reference copy
+        args=config,
+        train_dataset=dataset,
+        tokenizer=tokenizer,
+        grpo_alpha=0.05, # Hyperparameter for the entropy bonus
+    )
+
+    print("Starting EDGE-GRPO training...")
+    trainer.train()
+    print("Training finished.")
+
+if __name__ == "__main__":
+    run_experiment()


### PR DESCRIPTION
This experiment integrates the core concept from EDGE-GRPO, an advanced reinforcement learning algorithm, into the VQASynth project. The VQASynth pipeline is designed to generate data for enhancing the spatial reasoning capabilities of Vision-Language Models (VLMs), often involving Chain-of-Thought (CoT) or step-by-step reasoning. Standard RL fine-tuning methods on such data can suffer from 'advantage collapse,' where similar rewards for different reasoning paths provide a poor learning signal.

The SOURCE repo, EDGE-GRPO, addresses this problem by introducing an 'Entropy-Driven Advantage'. By adding a policy entropy bonus to the advantage calculation, the algorithm encourages response diversity and maintains a stronger gradient signal, leading to more robust and effective learning. This is particularly relevant for complex reasoning tasks where multiple valid paths to a solution might exist.

This experiment proposes a minimal implementation of an EDGE-GRPO trainer to fine-tune a VLM on spatial reasoning data. The goal is to test the hypothesis that applying this entropy-augmented RL algorithm can improve the VLM's spatial reasoning performance and training efficiency compared to standard RL techniques, by better exploring the space of possible reasoning steps.


### Test Strategy
- Execute the new experiment script: `python experiments/edge_grpo_tuning/run.py`.
- Verify that the script completes without errors and outputs training loss metrics to the console.
- Inspect the logs to confirm that the custom `EdgeGRPOTrainer` is used and that metrics like `policy/entropy` and `rewards/edge_advantage` are being calculated and logged.


### Success Criteria
- The training script runs to completion and shows a stable, decreasing loss, demonstrating the viability of the EDGE-GRPO loss function.
- The logged `rewards/edge_advantage` metric should be consistently higher than `rewards/advantage`, confirming that the entropy bonus is being applied correctly.
- A full training run on a VQASynth-generated dataset, when evaluated on a spatial reasoning benchmark, should show a performance improvement over a model trained with a standard DPO/PPO algorithm.


**Labels:** experiment

---
**Source:** https://github.com/ZhangXJ199/EDGE-GRPO
**Evidence:**
- `README.md`
- `evaluate_model.py`
- `train_grpo.sh`