### PR TITLE
feat(experiment): Add temporal logic VQA task

### DIFF
--- a/experiments/temporal-logic-vqa/run.py
+++ b/experiments/temporal-logic-vqa/run.py
@@ -1,0 +1,139 @@
+import json
+import os
+from pathlib import Path
+import argparse
+
+# This script is designed to process output from the LTLZinc generator.
+# The generator creates a directory for each task, e.g., 'mnist_add'.
+# Inside, it produces train/val/test splits, each with an 'images' folder
+# and a 'meta.json' file.
+#
+# The 'meta.json' file contains the ground truth for each generated sequence:
+# [
+#   {
+#     "trace_id": 0,
+#     "trace_satisfies_formula": true,
+#     "streams": {
+#       "w": [ { "t": 0, "class": 1 }, { "t": 1, "class": 9 }, ... ],
+#       "x": [ { "t": 0, "class": 8 }, { "t": 1, "class": 0 }, ... ],
+#       "y": [ { "t": 0, "class": 4 }, { "t": 1, "class": 3 }, ... ],
+#       "z": [ { "t": 0, "class": 5 }, { "t": 1, "class": 7 }, ... ]
+#     }
+#   },
+#   ...
+# ]
+
+def load_ltlzinc_sample(dataset_path: Path, trace_id: int):
+    """
+    Loads a single trace (image sequence and metadata) from an LTLZinc-generated dataset.
+    """
+    meta_path = dataset_path / "meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"'meta.json' not found in {dataset_path}. "
+                                "Please generate the LTLZinc dataset first.")
+
+    with open(meta_path, 'r') as f:
+        metadata = json.load(f)
+
+    sample_meta = next((item for item in metadata if item['trace_id'] == trace_id), None)
+    if sample_meta is None:
+        raise ValueError(f"Trace with ID {trace_id} not found in metadata.")
+
+    # Reconstruct the image sequence paths from the metadata.
+    # This assumes a structure like 'images/<class_name>/<image_file>', which is typical.
+    sequence_length = len(sample_meta['streams']['w'])
+    image_sequence = []
+    for t in range(sequence_length):
+        timestep_images = {}
+        for stream_name in ['w', 'x', 'y', 'z']:
+            class_val = sample_meta['streams'][stream_name][t]['class']
+            # We represent the image by a descriptive path placeholder.
+            # A real data loader would resolve this to an actual file.
+            img_path = dataset_path / "images" / str(class_val) / f"trace_{trace_id}_t_{t}_{stream_name}.png"
+            timestep_images[stream_name] = str(img_path)
+        image_sequence.append(timestep_images)
+
+    return {
+        "trace_id": trace_id,
+        "image_sequence_paths": image_sequence,
+        "satisfies_formula": sample_meta['trace_satisfies_formula']
+    }
+
+def create_temporal_vqa_prompt(sample_data):
+    """
+    Creates a VQA prompt for the 'mnist_add' temporal reasoning task.
+
+    The LTL formula for this task is: "G (p(W,X,Y,Z) <-> WX !p(W,X,Y,Z))"
+    where p(W,X,Y,Z) is "W + X = Y + Z".
+    This translates to: At every point in time, the property p is true if and only if
+    in the next step, property p is false. This defines a strict alternating pattern.
+    """
+    question = (
+        "You will be shown a sequence of timesteps. Each timestep has four images of handwritten digits, "
+        "labeled W, X, Y, and Z. "
+        "Does this entire sequence satisfy the following temporal rule: 'For any given timestep, the sum of digits W+X equals Y+Z "
+        "if and only if at the very next timestep, the sum W+X does NOT equal Y+Z'? "
+        "Answer with only 'yes' or 'no'."
+    )
+
+    answer = "yes" if sample_data['satisfies_formula'] else "no"
+
+    return {
+        "id": f"temporal_mnist_add_{sample_data['trace_id']}",
+        "image_sequence": sample_data['image_sequence_paths'],
+        "conversations": [
+            {
+                "from": "human",
+                "value": question
+            },
+            {
+                "from": "gpt",
+                "value": answer
+            }
+        ]
+    }
+
+def main():
+    """
+    Main function to generate and print a sample temporal VQA prompt.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate a VQA sample for a temporal logic task from LTLZinc output."
+    )
+    parser.add_argument(
+        "--dataset_path",
+        type=Path,
+        required=True,
+        help="Path to a split in an LTLZinc-generated dataset (e.g., './mnist_add/test')."
+    )
+    parser.add_argument(
+        "--trace_id",
+        type=int,
+        default=0,
+        help="The trace ID to use for generating the sample."
+    )
+    args = parser.parse_args()
+
+    print(f"Attempting to load sample from LTLZinc dataset at: {args.dataset_path}")
+
+    try:
+        sample_data = load_ltlzinc_sample(args.dataset_path, args.trace_id)
+        vqa_prompt = create_temporal_vqa_prompt(sample_data)
+
+        print("\n--- Generated Temporal VQA Sample ---")
+        print(json.dumps(vqa_prompt, indent=2))
+        print("\n--- End of Sample ---")
+
+        print("\nThis demonstrates how a VQA sample can be constructed from LTLZinc output.")
+        print("The 'image_sequence' contains placeholder paths to images for each timestep.")
+        print("The 'conversations' key follows a standard format for VLM instruction tuning,")
+        print("pairing a natural language question about a temporal rule with a ground-truth answer.")
+
+    except (FileNotFoundError, ValueError) as e:
+        print(f"\nError: {e}")
+        print("\nPlease ensure you have run the LTLZinc generator and provided the correct path.")
+        print("For example, using the LTLZinc Docker setup, data will be in 'benchmark/tasks/mnist_add'.")
+        print(f"Then run this script with: --dataset_path /path/to/mnist_add/test")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates concepts from LTLZinc to introduce a temporal reasoning task into the VQASynth framework. While VQASynth primarily focuses on enhancing spatial reasoning from single static images, LTLZinc provides a powerful generator for creating sequences of images governed by formal temporal logic rules (LTL). This creates an opportunity to test and train Vision Language Models on their ability to understand and verify temporal patterns, a crucial capability for agents operating in dynamic environments.

This proposal introduces a minimal, self-contained experiment that leverages an LTLZinc-generated dataset. Specifically, it uses a simple task where a sequence of MNIST digit images must adhere to an alternating arithmetic rule (`W+X = Y+Z` is true if and only if it is false in the next timestep). The experiment consists of a script that loads a sample sequence and its ground-truth label, then formats it into a VQA-style prompt. The question asks the model to verify if the sequence follows the temporal rule, and the answer is a simple 'yes' or 'no'.

By framing a temporal logic problem as a VQA task, we can benchmark a VLM's capacity for sequential and logical reasoning. This extends the scope of VQASynth beyond spatial awareness to encompass the time dimension, creating a path for developing models with more comprehensive reasoning abilities.


### Test Strategy
- Build the Docker image provided in the LTLZinc repository. The entrypoint will automatically run the generator and create the 'mnist_add' dataset in `/app/benchmark/tasks/mnist_add` inside the container.
- Copy the generated dataset (e.g., the 'test' split directory `mnist_add/test`) from the Docker container to the host machine where the TARGET repo is checked out.
- Run the new experiment script: `python experiments/temporal-logic-vqa/run.py --dataset_path /path/to/mnist_add/test`.
- Verify that the script executes without errors and prints a JSON object representing the VQA sample. The 'answer' in the JSON should correctly reflect the 'trace_satisfies_formula' value in the corresponding 'meta.json' entry.


### Success Criteria
- The experiment script successfully loads an image sequence trace and its corresponding metadata from the LTLZinc-generated dataset.
- The script correctly formulates a natural language question that accurately represents the temporal logic formula (`G (p <-> X !p)`) used to generate the data.
- The script produces a well-formed JSON output containing the image sequence, the question, and the correct 'yes'/'no' answer, suitable for integration into a VLM fine-tuning pipeline.


**Labels:** experiment

---
**Source:** https://github.com/continual-nesy/LTLZinc
**Evidence:**
- `README.md`
- `example_config.yml`