### PR TITLE
Feat: Add VeOmni-inspired trainer-free training script

### DIFF
--- a/experiments/veomni_trainer/run.py
+++ b/experiments/veomni_trainer/run.py
@@ -1,0 +1,97 @@
+import argparse
+import logging
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from transformers import AutoModelForCausalLM, AutoTokenizer, get_scheduler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+
+
+def get_dummy_dataloader(batch_size, seq_length, vocab_size):
+    """Creates a dummy dataloader for demonstration purposes."""
+    num_samples = 100
+    input_ids = torch.randint(0, vocab_size, (num_samples, seq_length), dtype=torch.long)
+    attention_mask = torch.ones_like(input_ids)
+    labels = input_ids.clone()
+    dataset = TensorDataset(input_ids, attention_mask, labels)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+def main(args):
+    """Main training function inspired by VeOmni's linear script design."""
+    logging.info("Starting VeOmni-inspired trainer-free script")
+
+    # 1. Initialization (similar to VeOmni setup)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logging.info(f"Using device: {device}")
+
+    # 2. Load Model and Tokenizer (a core component)
+    logging.info(f"Loading model: {args.model_name}")
+    # In a real scenario, this would be a VLM like LLaVA or a model from VeOmni's examples
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(args.model_name).to(device)
+
+    # 3. Data Loading (would use vqasynth.datasets in a real implementation)
+    logging.info("Preparing DataLoader")
+    # This part would be replaced by a call to load a VQASynth-generated dataset
+    train_dataloader = get_dummy_dataloader(
+        args.batch_size,
+        args.seq_length,
+        tokenizer.vocab_size
+    )
+
+    # 4. Optimizer and Scheduler setup
+    logging.info(f"Setting up optimizer with learning rate: {args.lr}")
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+
+    num_training_steps = args.max_steps
+    lr_scheduler = get_scheduler(
+        name="linear",
+        optimizer=optimizer,
+        num_warmup_steps=0,
+        num_training_steps=num_training_steps,
+    )
+
+    # 5. The Training Loop (the "trainer-free" core)
+    logging.info("Starting training loop...")
+    model.train()
+    step = 0
+    while step < args.max_steps:
+        for batch in train_dataloader:
+            if step >= args.max_steps:
+                break
+
+            batch = {k: v.to(device) for k, v in zip(["input_ids", "attention_mask", "labels"], batch)}
+
+            optimizer.zero_grad()
+
+            outputs = model(**batch)
+            loss = outputs.loss
+            loss.backward()
+
+            optimizer.step()
+            lr_scheduler.step()
+
+            if step % args.log_interval == 0:
+                logging.info(f"Step {step}/{args.max_steps}, Loss: {loss.item():.4f}")
+            
+            step += 1
+
+    logging.info("Training finished successfully.")
+
+if __name__ == "__main__":
+    # Configuration is handled by simple argument parsing, a key VeOmni principle
+    parser = argparse.ArgumentParser(description="Minimal Trainer-Free Script")
+    parser.add_argument("--model_name", type=str, default="gpt2", help="Model to train.")
+    parser.add_argument("--max_steps", type=int, default=20, help="Total training steps.")
+    parser.add_argument("--batch_size", type=int, default=2, help="Batch size per device.")
+    parser.add_argument("--seq_length", type=int, default=64, help="Sequence length of dummy data.")
+    parser.add_argument("--lr", type=float, default=5e-5, help="Learning rate.")
+    parser.add_argument("--log_interval", type=int, default=5, help="Interval for logging training status.")
+
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
The VQASynth repository provides excellent tools for generating spatial reasoning datasets but lacks an integrated training pipeline. This experiment introduces a training component inspired by the design philosophy of VeOmni, a framework for scaling multimodal model training. VeOmni advocates for a "trainer-free" approach, where training logic is expressed in simple, linear scripts rather than being abstracted away in complex trainer classes. This design choice maximizes transparency and control for the developer.

We propose adding a minimal, self-contained training script that embodies this principle. The script will consume data generated by VQASynth and fine-tune a vision-language model. It will use a straightforward argument parser for configuration and expose the entire training loop—from data loading to optimization steps—directly in the script. This follows the model-centric, decoupled design seen in VeOmni's example training tasks.

This experiment aims to validate the hypothesis that a transparent, trainer-free script is a more flexible and extensible solution for the research-oriented goals of VQASynth than integrating a high-level library like HuggingFace's `Trainer`. Success would pave the way for a more robust, end-to-end workflow within the VQASynth project, from data synthesis to model fine-tuning.


### Test Strategy
- Build the Docker container provided in the `experimental-vqasynth` repository.
- Execute the new training script within the container: `python experiments/veomni_trainer/run.py --max_steps 10`.
- Verify that the script runs to completion without errors, printing loss values to the console at each logging interval.


### Success Criteria
- The training script completes without errors.
- Log output confirms that the training loop iterates and calculates loss.
- The script's structure is demonstrably linear and transparent, validating the 'trainer-free' approach for this use case.


**Labels:** experiment, training-framework

---
**Source:** https://github.com/ByteDance-Seed/VeOmni
**Evidence:**
- `README.md`
- `train.sh`