### PR TITLE
Feat: Integrate MC-Dropout for Depth Estimation Uncertainty

### DIFF
--- a/experiments/depth_uncertainty/run.py
+++ b/experiments/depth_uncertainty/run.py
@@ -1,0 +1,106 @@
+import torch
+import numpy as np
+import requests
+from PIL import Image
+from transformers import DPTForDepthEstimation, DPTImageProcessor
+import matplotlib.pyplot as plt
+import os
+
+def enable_dropout(model):
+    """ Function to enable the dropout layers during test-time """
+    for m in model.modules():
+        if m.__class__.__name__.startswith('Dropout'):
+            m.train()
+
+def run_mc_dropout_depth_estimation(image_url, n_samples=15, output_dir="output/depth_uncertainty"):
+    """
+    Performs depth estimation using Monte Carlo Dropout to quantify uncertainty.
+
+    Args:
+        image_url (str): URL of the input image.
+        n_samples (int): Number of forward passes for MC Dropout.
+        output_dir (str): Directory to save the output plots.
+    """
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Load image from URL
+    try:
+        image = Image.open(requests.get(image_url, stream=True).raw).convert("RGB")
+    except Exception as e:
+        print(f"Error loading image: {e}")
+        return
+
+    # Load a pretrained depth estimation model and processor
+    model_name = "Intel/dpt-hybrid-midas"
+    processor = DPTImageProcessor.from_pretrained(model_name)
+    model = DPTForDepthEstimation.from_pretrained(model_name)
+    
+    # Enable dropout layers for uncertainty estimation. 
+    # The DPT model has dropout layers in its ViT backbone.
+    enable_dropout(model)
+    
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device)
+    print(f"Using device: {device}")
+
+    # Store predictions from each forward pass
+    predictions = []
+
+    print(f"Running {n_samples} forward passes for MC Dropout...")
+    with torch.no_grad():
+        for i in range(n_samples):
+            print(f"  - Pass {i+1}/{n_samples}")
+            # Prepare image for the model
+            inputs = processor(images=image, return_tensors="pt").to(device)
+            
+            # Predict depth
+            outputs = model(**inputs)
+            predicted_depth = outputs.predicted_depth
+
+            # Interpolate to original size
+            prediction = torch.nn.functional.interpolate(
+                predicted_depth.unsqueeze(1),
+                size=image.size[::-1],
+                mode="bicubic",
+                align_corners=False,
+            ).squeeze()
+            
+            predictions.append(prediction.cpu())
+
+    # Stack predictions and calculate mean and variance
+    predictions_tensor = torch.stack(predictions)
+    mean_depth = predictions_tensor.mean(axis=0)
+    variance_depth = predictions_tensor.var(axis=0)
+
+    print("Generating and saving plots...")
+
+    # Plotting
+    fig, axes = plt.subplots(1, 3, figsize=(18, 6))
+    
+    # Original Image
+    axes[0].imshow(image)
+    axes[0].set_title("Input Image")
+    axes[0].axis("off")
+    
+    # Mean Depth
+    im1 = axes[1].imshow(mean_depth.numpy(), cmap="plasma")
+    axes[1].set_title("Mean Depth Prediction")
+    axes[1].axis("off")
+    fig.colorbar(im1, ax=axes[1], orientation='horizontal', fraction=0.05, pad=0.1)
+
+    # Uncertainty (Variance)
+    im2 = axes[2].imshow(variance_depth.numpy(), cmap="magma")
+    axes[2].set_title("Uncertainty (Variance)")
+    axes[2].axis("off")
+    fig.colorbar(im2, ax=axes[2], orientation='horizontal', fraction=0.05, pad=0.1)
+
+    plt.tight_layout()
+    output_path = os.path.join(output_dir, "depth_uncertainty_analysis.png")
+    plt.savefig(output_path)
+    print(f"Saved analysis to {output_path}")
+
+if __name__ == "__main__":
+    # Using one of the sample images from the VQASynth README
+    sample_image_url = "https://github.com/remyxai/VQASynth/blob/main/assets/warehouse_sample_1.jpeg?raw=true"
+    run_mc_dropout_depth_estimation(sample_image_url)


### PR DESCRIPTION
The SOURCE repository, 'comprehensive-framework-ivim', highlights the critical need for uncertainty quantification (UQ) in deep learning models, particularly for dense prediction tasks like those in medical imaging. By understanding a model's confidence, we can build more reliable and trustworthy AI systems. This principle is highly relevant to the TARGET 'experimental-vqasynth' project, which generates spatial reasoning data for VLMs based on a series of model predictions, most notably depth estimation.

Errors or high uncertainty in the depth estimation stage can propagate through the VQASynth pipeline, leading to the creation of inaccurate or nonsensical spatial Question-Answering pairs. This pollutes the final training dataset and can hinder a VLM's ability to learn robust spatial reasoning. To address this, we propose an experiment to integrate a well-established UQ technique, Monte Carlo (MC) Dropout, into the depth estimation module.

This experiment introduces a self-contained script that runs a depth estimation model multiple times with dropout enabled during inference. By calculating the variance of these predictions, we can generate an 'uncertainty map' alongside the standard depth map. This map visually highlights regions where the model is least confident, such as object boundaries, reflective surfaces, or distant areas. This information could be used to filter out low-quality data points, ultimately improving the fidelity of the synthetic VQA datasets and the performance of models trained on them. This serves as a minimal, practical first step in applying the UQ principles from the SOURCE project to enhance the TARGET pipeline.


### Test Strategy
- Build the Docker image using the provided Dockerfile in the target repository: `docker build -t vqasynth-uncertainty .`
- Run the experiment script within a container, mounting a local directory to retrieve the output: `docker run --gpus all --rm -v "$(pwd)/output:/app/output" vqasynth-uncertainty python experiments/depth_uncertainty/run.py`
- Verify that the script completes without errors and that an output image named 'depth_uncertainty_analysis.png' is saved to the 'output/depth_uncertainty' directory.


### Success Criteria
- The experiment script must successfully generate and save a single PNG file containing three subplots: the original input image, the mean depth prediction, and the uncertainty (variance) map.
- The resulting uncertainty map must be qualitatively meaningful, showing higher variance (brighter colors in the 'magma' colormap) in regions known to be challenging for monocular depth estimation, such as object edges, textureless surfaces, or areas far from the camera.


**Labels:** experiment

---
**Source:** https://github.com/Bio-SimPro-Lab/comprehensive-framework-ivim.git
**Evidence:**
- `README.md`