### PR TITLE
feat: Add hallucination filter stage using token entropy

### DIFF
--- a/docker/hallucination_filter_stage/Dockerfile
+++ b/docker/hallucination_filter_stage/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.4
+# Base image aligned with SOURCE repo environment for consistency
+FROM pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel
+
+# System dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Python dependencies for the script
+RUN pip install --no-cache-dir transformers==4.41.2 accelerate==0.30.1 tqdm
+
+# Copy the processing script and its entrypoint
+COPY process_hallucinations.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Set Hugging Face cache to a shared volume to avoid re-downloading models
+ENV HF_HOME=/data/cache
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/hallucination_filter_stage/entrypoint.sh
+++ b/docker/hallucination_filter_stage/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# These variables are expected to be set by an orchestration script (e.g., run.sh).
+# Default values are provided for clarity and to enable standalone testing.
+# The paths assume a /data volume is mounted into the container.
+INPUT_FILE=${INPUT_FILE:-"/data/prompt_stage/output.jsonl"}
+OUTPUT_FILE=${OUTPUT_FILE:-"/data/hallucination_filter_stage/filtered_output.jsonl"}
+MODEL_NAME=${MODEL_NAME:-"mistralai/Mistral-7B-v0.1"}
+ENTROPY_THRESHOLD=${ENTROPY_THRESHOLD:-"1.5"}
+
+echo "--- Running Hallucination Filter Stage ---"
+echo "Input file: $INPUT_FILE"
+echo "Output file: $OUTPUT_FILE"
+echo "Model for logit reproduction: $MODEL_NAME"
+echo "First-token entropy threshold: $ENTROPY_THRESHOLD"
+
+# Execute the processing script with the provided arguments
+python /app/process_hallucinations.py \
+    --input_file "$INPUT_FILE" \
+    --output_file "$OUTPUT_FILE" \
+    --model_name "$MODEL_NAME" \
+    --entropy_threshold "$ENTROPY_THRESHOLD"
+
+echo "--- Hallucination Filter Stage Complete ---"

--- a/docker/hallucination_filter_stage/process_hallucinations.py
+++ b/docker/hallucination_filter_stage/process_hallucinations.py
@@ -1,0 +1,157 @@
+import os
+import json
+import torch
+import argparse
+import logging
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from torch.nn import functional as F
+from tqdm import tqdm
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+def calculate_entropy(logits):
+    """Calculates the Shannon entropy for a given logit tensor."""
+    # logits shape: (batch_size, sequence_length, vocab_size)
+    probs = F.softmax(logits, dim=-1)
+    log_probs = F.log_softmax(logits, dim=-1)
+    entropy = -torch.sum(probs * log_probs, dim=-1)
+    return entropy
+
+
+def process_and_filter(input_file, output_file, model_name, entropy_threshold, device):
+    """
+    Processes VQA pairs, calculates the entropy of the first generated token
+    of the answer, and filters out samples above a given entropy threshold.
+    """
+    logging.info(f"Loading model and tokenizer: {model_name}")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name, torch_dtype=torch.bfloat16
+    ).to(device)
+    model.eval()
+
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    filtered_samples = []
+    total_samples = 0
+    filtered_out_count = 0
+
+    with open(input_file, "r") as f_in:
+        lines = f_in.readlines()
+        total_samples = len(lines)
+        logging.info(f"Found {total_samples} samples in {input_file}")
+
+        for line in tqdm(lines, desc="Analyzing sample uncertainty"):
+            try:
+                data = json.loads(line)
+                # Assumes LLaVA-style conversation format: [{"from": "human", ...}, {"from": "gpt", ...}]
+                prompt = data["conversations"][0]["value"]
+                answer = data["conversations"][1]["value"]
+
+                # Tokenize prompt and answer to find the boundary
+                prompt_tokens = tokenizer(
+                    prompt, return_tensors="pt", add_special_tokens=True
+                ).to(device)
+
+                # We need the full input to reproduce the logits that generated the answer
+                full_text = prompt + answer
+                full_input_ids = (
+                    tokenizer(full_text, return_tensors="pt", add_special_tokens=True)
+                    .to(device)
+                    .input_ids
+                )
+
+                with torch.no_grad():
+                    outputs = model(input_ids=full_input_ids)
+                    logits = outputs.logits
+
+                # The logit for predicting token `i` is at `logits[:, i-1, :]`.
+                # We want the logits for the first token of the answer.
+                prompt_len = prompt_tokens.input_ids.shape[1]
+                answer_logits = logits[
+                    :, prompt_len - 1 : -1, :
+                ]  # Logits that predict each token of the answer
+
+                if answer_logits.shape[1] == 0:
+                    logging.warning(
+                        "Skipping sample with empty answer after tokenization."
+                    )
+                    continue
+
+                # The core idea from RAGTruth_Xtended: focus on the first token's signal
+                first_token_logits = answer_logits[:, 0, :].unsqueeze(
+                    1
+                )  # Keep dimensions for entropy function
+                first_token_entropy = calculate_entropy(first_token_logits)[0, 0].item()
+
+                if first_token_entropy <= entropy_threshold:
+                    filtered_samples.append(data)
+                else:
+                    filtered_out_count += 1
+
+            except (json.JSONDecodeError, KeyError, IndexError) as e:
+                logging.warning(
+                    f"Skipping malformed line or data structure: {e}. Line: {line.strip()}"
+                )
+                continue
+
+    logging.info(
+        f"Finished processing. Total samples: {total_samples}. Filtered out: {filtered_out_count}. Kept: {len(filtered_samples)}."
+    )
+
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+
+    with open(output_file, "w") as f_out:
+        for sample in filtered_samples:
+            f_out.write(json.dumps(sample) + "\n")
+
+    logging.info(f"Filtered dataset saved to {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Filter VQA data based on first-token entropy of the answer."
+    )
+    parser.add_argument(
+        "--input_file", type=str, required=True, help="Path to the input JSONL file."
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        required=True,
+        help="Path to save the filtered JSONL file.",
+    )
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="mistralai/Mistral-7B-v0.1",
+        help="Hugging Face model to use for logit reproduction.",
+    )
+    parser.add_argument(
+        "--entropy_threshold",
+        type=float,
+        default=1.5,
+        help="Entropy threshold for filtering. Samples with higher first-token entropy will be discarded.",
+    )
+
+    args = parser.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    logging.info(f"Using device: {device}")
+
+    process_and_filter(
+        input_file=args.input_file,
+        output_file=args.output_file,
+        model_name=args.model_name,
+        entropy_threshold=args.entropy_threshold,
+        device=device,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates concepts from RAGTruth_Xtended into the VQASynth data generation pipeline. The source repository demonstrates that the first token of a hallucinated sequence often exhibits higher uncertainty (e.g., entropy) than subsequent tokens. By measuring this signal, we can identify and filter out potentially low-quality or hallucinated responses in real-time.

We propose a new, self-contained Docker stage for the VQASynth pipeline called `hallucination_filter_stage`. This stage runs after the initial prompt generation (`prompt_stage`) and before the final training (`llava_train`). It recalculates the logits for each generated answer, computes the entropy of the first token, and discards any question-answer pair where this entropy exceeds a defined threshold.

By culling low-confidence synthetic data, we hypothesize that the resulting fine-tuned Vision Language Model will be more robust, more accurate, and less prone to hallucination. This leverages the core analytical insight from the source paper to practically improve the data quality and model performance in the target repository.


### Test Strategy
- Build the Docker image for the new stage: `docker build -t hallucination-filter:latest docker/hallucination_filter_stage/`
- Prepare a sample input file (`/data/prompt_stage/output.jsonl`) with a few dozen VQA pairs in the expected JSONL format.
- Run the Docker container, mounting a local data directory: `docker run --gpus all -v $(pwd)/data:/data hallucination-filter:latest`.
- Verify that the container runs successfully and creates an output file at `/data/hallucination_filter_stage/filtered_output.jsonl`.
- Check the logs to confirm that some samples were filtered out based on the entropy threshold.
- Compare the number of lines in the input and output files (`wc -l <file>`) to confirm that filtering occurred.


### Success Criteria
- The `hallucination_filter_stage` successfully processes an input JSONL file and produces a filtered output JSONL file.
- The number of samples in the output dataset is less than or equal to the number in the input dataset, demonstrating that the filtering logic is active.
- A qualitative review of filtered-out samples shows they are often more generic, nonsensical, or less confident answers compared to the samples that were kept.


**Labels:** data-synthesis, hallucination-detection

---
**Source:** https://github.com/jakobsnl/RAGTruth_Xtended
**Evidence:**
- `README.md`
- `rtx/analyse_hallucination.py`
- `rtx/create_dataset.py`

**Experiment metadata:**
- experiment_id: local-1755116158
- run_id: run-1
- paper_id: 2507.20836v1
