### PR TITLE
Feat: Integrate Compact VLM as a Data Quality Filter

### DIFF
--- a/docker/filter_stage/process_filter.py
+++ b/docker/filter_stage/process_filter.py
@@ -1,62 +1,174 @@
-import os
-import pickle
 import argparse
-import pandas as pd
+import json
+import os
+import re
+from pathlib import Path
+
+import torch
 from PIL import Image
-from vqasynth.datasets import Dataloader
-from vqasynth.embeddings import TagFilter
-from vqasynth.utils import filter_null
+from tqdm import tqdm
+from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
+
+# Regex to extract the score from the model's output
+SCORE_PATTERN = re.compile(r"score:\s*\{(\d+)\}")
 
 
-def main(output_dir, source_repo_id, include_tags, exclude_tags, confidence_threshold=0.7):
-    tag_filter = TagFilter()
-    dataloader = Dataloader(output_dir)
+class VLMJudgeFilter:
+    """
+    Uses a compact VLM to judge the quality and alignment of image-caption pairs.
+    This class is an adaptation of the methodology from the "Compact_VLM_Filter" repository.
+    """
 
-    dataset = dataloader.load_dataset(source_repo_id)
+    def __init__(self, model_path: str, batch_size: int = 32, device: str = "cuda"):
+        self.batch_size = batch_size
+        self.device = device
 
-    include_tags = [tag.strip() for tag in include_tags.split(",")]
-    exclude_tags = [tag.strip() for tag in exclude_tags.split(",")]
+        print(f"Loading VLM judge model from {model_path}...")
+        self.processor = AutoProcessor.from_pretrained(
+            model_path, trust_remote_code=True
+        )
+        self.model = Qwen2VLForConditionalGeneration.from_pretrained(
+            model_path, device_map=self.device, torch_dtype=torch.float16
+        )
+        self.model.eval()
+        print("VLM judge model loaded successfully.")
 
-    def process_and_filter(batch):
+    def _create_prompts(self, captions: list[str]) -> list[str]:
+        """Creates the batch of prompts for the VLM judge."""
+        # This prompt structure is inferred from the fine-tuning of the judge model.
+        # It asks for a structured score output.
+        prompt_template = "Is the caption appropriate for the image? Please give me a score from 1 to 10. score: {{score}}"
+
+        messages = []
+        for caption in captions:
+            # The structure <|im_start|><image><|im_end|> is handled by the processor
+            # when text and images are passed together. We just need the text part.
+            text_content = f"{caption}\n{prompt_template}"
+            messages.append(text_content)
+        return messages
+
+    def get_scores(self, image_paths: list[str], captions: list[str]) -> list[int]:
         """
-        Return a list[bool] mask for a batch, or a single bool for a single example.
+        Processes a batch of images and captions to get alignment scores.
+        Returns a list of scores, with -1 indicating an error for that item.
         """
-        # Batched: HF datasets give lists
-        batched = isinstance(next(iter(batch.values())), list)
+        scores = [-1] * len(image_paths)
+        try:
+            images = [Image.open(p).convert("RGB") for p in image_paths]
+            prompts = self._create_prompts(captions)
 
-        if batched:
-            size = len(batch['tag'])
-            keep = []
-            for i in range(size):
-                row = {k: batch[k][i] for k in batch}
-                ok_tag = tag_filter.filter_by_tag(row['tag'], include_tags, exclude_tags)
-                ok_null = all(v is not None for v in row.values())
-                keep.append(ok_tag and ok_null)
-            return keep
-        else:
-            ok_tag = tag_filter.filter_by_tag(batch['tag'], include_tags, exclude_tags)
-            ok_null = all(v is not None for v in batch.values())
-            return ok_tag and ok_null
+            inputs = self.processor(
+                text=prompts, images=images, return_tensors="pt", padding=True
+            ).to(self.device)
 
-    dataset = dataset.map(
-        tag_filter.apply_transform,
-        fn_kwargs={'tags': include_tags + exclude_tags},
-        batched=True,
-        batch_size=32
+            with torch.no_grad():
+                gen_kwargs = {"max_new_tokens": 20}
+                outputs = self.model.generate(**inputs, **gen_kwargs)
+
+            # Decode and parse scores
+            responses = self.processor.batch_decode(outputs, skip_special_tokens=True)
+            for i, response in enumerate(responses):
+                match = SCORE_PATTERN.search(response)
+                if match:
+                    scores[i] = int(match.group(1))
+                else:
+                    print(f"Warning: Could not parse score from response: '{response}'")
+        except Exception as e:
+            print(f"Error processing batch: {e}")
+            # All items in this batch will have a score of -1
+
+        return scores
+
+    def filter_dataset(self, data: list[dict], score_threshold: int) -> list[dict]:
+        """
+        Filters a dataset based on the VLM judge's scores.
+        Assumes data is a list of dicts, each with "image_path" and "caption".
+        """
+        filtered_data = []
+
+        # Process data in batches
+        for i in tqdm(
+            range(0, len(data), self.batch_size), desc="Filtering with VLM Judge"
+        ):
+            batch = data[i : i + self.batch_size]
+            image_paths = [item["image_path"] for item in batch]
+            captions = [item["caption"] for item in batch]
+
+            scores = self.get_scores(image_paths, captions)
+
+            for item, score in zip(batch, scores):
+                if score >= score_threshold:
+                    item["quality_score"] = score  # Add score to the output data
+                    filtered_data.append(item)
+                else:
+                    print(
+                        f"Filtering out item with score {score}: {item['image_path']}"
+                    )
+
+        return filtered_data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Filter image-caption datasets using a VLM Judge."
+    )
+    parser.add_argument(
+        "--input_path", type=str, required=True, help="Path to the input JSON file."
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Path to save the filtered output JSON file.",
+    )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="Dauka-transformers/Compact_VLM_filter",
+        help="Path or HF repo for the VLM judge model.",
+    )
+    parser.add_argument(
+        "--score_threshold",
+        type=int,
+        default=5,
+        help="Minimum score (inclusive) to keep an item.",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=16, help="Batch size for processing."
     )
 
-    # Filter out examples in a single pass (nulls and tag filtering combined)
-    dataset_filtered = dataset.filter(process_and_filter, batched=True, batch_size=32)
+    args = parser.parse_args()
 
-    dataloader.save_to_disk(dataset_filtered)
+    print(f"Loading data from: {args.input_path}")
+    try:
+        with open(args.input_path, "r") as f:
+            input_data = json.load(f)
+    except Exception as e:
+        print(f"Error loading input data: {e}")
+        return
 
-    print(f"Dataset filtering complete")
+    if not isinstance(input_data, list) or not all(
+        "image_path" in d and "caption" in d for d in input_data
+    ):
+        print(
+            "Invalid input data format. Expected a JSON list of objects, each with 'image_path' and 'caption'."
+        )
+        return
+
+    vlm_filter = VLMJudgeFilter(model_path=args.model_path, batch_size=args.batch_size)
+    filtered_data = vlm_filter.filter_dataset(input_data, args.score_threshold)
+
+    output_dir = Path(args.output_path).parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(args.output_path, "w") as f:
+        json.dump(filtered_data, f, indent=2)
+
+    print(
+        f"Filtering complete. Original items: {len(input_data)}, Filtered items: {len(filtered_data)}"
+    )
+    print(f"Filtered data saved to: {args.output_path}")
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser("Filter dataset by tags", add_help=True)
-    parser.add_argument("--output_dir", type=str, required=True, help="path to output dataset directory")
-    parser.add_argument("--source_repo_id", type=str, required=True, help="Source huggingface dataset repo id")
-    parser.add_argument("--include_tags", type=str, required=False, default=None, help="Comma-separated list of tags to include (optional)")
-    parser.add_argument("--exclude_tags", type=str, required=False, default=None, help="Comma-separated list of tags to exclude (optional)")
-    args = parser.parse_args()
-    main(args.output_dir, args.source_repo_id, args.include_tags, args.exclude_tags)
+    main()


### PR DESCRIPTION
The VQASynth pipeline aims to generate high-quality synthetic VQA data for spatial reasoning. The quality of this generated data is highly dependent on the quality of the initial inputs and intermediate representations. Low-quality or misaligned image-caption pairs can propagate errors through the pipeline, resulting in flawed training examples that degrade the performance of the final fine-tuned model. A robust filtering mechanism is crucial to ensure a high-quality baseline.

This feature branch integrates the core concept from the `Compact_VLM_Filter` repository: using a small, specialized VLM as an "in-context judge" to efficiently score and filter data at scale. We implement this idea within the existing `filter_stage` of the VQASynth pipeline. This new stage uses the `Dauka-transformers/Compact_VLM_filter` model to evaluate the semantic alignment between images and their corresponding captions. By removing poorly aligned pairs early in the process, we can significantly improve the quality and consistency of the final synthetic dataset, leading to more effective VLM fine-tuning for spatial reasoning tasks.


### Test Strategy
- Build the `filter_stage` Docker image with the new script and dependencies (`transformers`, `accelerate`, `torch`).
- Prepare a sample `input.json` containing a list of objects, each with `image_path` and `caption` keys. Include both well-aligned and poorly-aligned pairs.
- Run the Docker container, mounting the input data and an output directory: `docker run --gpus all -v /path/to/data:/data vqasynth/filter_stage --input_path /data/input.json --output_path /data/output.json --score_threshold 5`.
- Verify that `output.json` is created and contains only the well-aligned pairs from the input file.
- Check that each entry in `output.json` now includes a `quality_score` field with a value greater than or equal to the specified threshold.


### Success Criteria
- The script successfully processes an input JSON file and produces a filtered output JSON file without crashing.
- The output file contains a subset of the input records, where items with a VLM-judged score below the threshold are removed.
- The log output correctly indicates which items are being filtered out and their corresponding scores.


**Labels:** data-synthesis, data-quality, experiment

---
**Source:** https://github.com/daulettoibazar/Compact_VLM_Filter
**Evidence:**
- `README.md`
- `scripts/filter_data.py`

**Experiment metadata:**
- experiment_id: local-1755116158
- run_id: run-1
- paper_id: 2507.20156v1
