### PR TITLE
Integrate POBAX RL Benchmark for Embodied Agent Training

### DIFF
--- a/experiments/pobax-benchmark/Dockerfile
+++ b/experiments/pobax-benchmark/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.4
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel
+
+# This container uses JAX. The PyTorch base image is a convenient
+# source for a pre-configured CUDA development environment.
+ENV CUDA_HOME=/usr/local/cuda-12.1
+
+WORKDIR /app
+
+# Install Python dependencies:
+# 1. Install JAX with CUDA support.
+# 2. Install the pobax library and its 'craftax' extra, which includes the
+#    navix dependency required for the DMLab maze environments.
+RUN pip install --no-cache-dir \
+    "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
+    "pobax[craftax]"
+
+# Copy the experiment runner script into the container
+COPY run.py .
+
+# Run the benchmark experiment
+CMD ["python", "run.py"]

--- a/experiments/pobax-benchmark/run.py
+++ b/experiments/pobax-benchmark/run.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+
+
+def main():
+    """
+    Runs the POBAX PPO agent on the Navix-DMLab-Maze-01-v0 environment.
+
+    This script serves as a simple entrypoint to benchmark a standard RL agent
+    on a task requiring spatial reasoning and memory, integrating the POBAX
+    benchmark suite into the experimental-vqasynth framework.
+
+    The arguments passed to the PPO script are chosen for a quick, debug-level
+    run to verify the integration.
+    """
+    # Command to run the PPO agent from the pobax library
+    # Using Navix-DMLab-Maze-01-v0 as it's a good test of spatial uncertainty.
+    # Arguments are set for a small-scale test run.
+    command = [
+        sys.executable,  # Use the current python interpreter
+        "-m",
+        "pobax.algos.ppo",
+        "--env",
+        "Navix-DMLab-Maze-01-v0",
+        "--total_steps",
+        "250000",
+        "--num_envs",
+        "16",
+        "--learning_rate",
+        "0.00025",
+        "--debug",
+        "--platform",
+        "gpu",
+    ]
+
+    print(f"Running command: {' '.join(command)}")
+
+    # Execute the command and stream output
+    try:
+        with subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        ) as process:
+            for line in process.stdout:
+                print(line, end="")
+
+        if process.returncode != 0:
+            raise subprocess.CalledProcessError(process.returncode, process.args)
+
+        print("\nPOBAX run completed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"\nPOBAX run failed with exit code {e.returncode}")
+        sys.exit(e.returncode)
+    except FileNotFoundError:
+        print("Error: python command not found. Is it in your PATH?")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The VQASynth project aims to improve spatial reasoning for embodied AI by generating specialized VQA datasets. To complement this data-centric approach, this experiment introduces a direct agent-centric benchmark using the POBAX library. POBAX provides a suite of reinforcement learning environments designed to test an agent's ability to handle partial observability, a critical skill for navigation and interaction in physical spaces. By integrating POBAX, we can establish a baseline for agent performance on tasks requiring memory and spatial understanding.

This branch introduces a self-contained experiment to train a standard Recurrent PPO agent on the `Navix-DMLab-Maze` environment from POBAX. This task directly evaluates an agent's navigation and memory capabilities in a controlled setting. The experiment is containerized, fitting into the existing Docker-based workflow of the VQASynth repository.

Establishing this benchmark will enable future work to directly compare the performance of agents trained on VQASynth-generated data against agents trained with pure reinforcement learning. It provides a foundational tool for evaluating how well different spatial reasoning capabilities transfer to active, embodied tasks.


### Test Strategy
- Navigate to the root of the target repository.
- Build the new Docker image using the command: `docker build -t vqasynth-pobax-benchmark -f experiments/pobax-benchmark/Dockerfile .`
- Run the container with GPU access: `docker run --rm --gpus all vqasynth-pobax-benchmark`.
- Monitor the container logs for training progress output from the PPO agent.


### Success Criteria
- The Docker container builds and runs without errors.
- The `run.py` script successfully invokes the `pobax` PPO training module.
- Training metrics, such as `mean_return` and `ep_length`, are logged to standard output, demonstrating that the agent is training in the environment.


**Labels:** embodied-ai-benchmark, rl-integration

---
**Source:** https://github.com/taodav/pobax
**Evidence:**
- `README.md`
- `pobax/algos/ppo.py`
- `pobax/envs/__init__.py`
- `pobax/envs/jax/navix_mazes.py`

**Experiment metadata:**
- experiment_id: local-1755116158
- run_id: run-1
- paper_id: 2508.00046v1
