### PR TITLE
Feat: Add DrUM script for generative image synthesis

### DIFF
--- a/experiments/drum_synthesis/run.py
+++ b/experiments/drum_synthesis/run.py
@@ -1,0 +1,92 @@
+import os
+import json
+import argparse
+import torch
+from diffusers import DiffusionPipeline
+from drum import DrUM
+from tqdm import tqdm
+
+
+def set_seed(seed: int):
+    """Sets the random seed for reproducibility."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate images using DrUM for the VQASynth pipeline."
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="runwayml/stable-diffusion-v1-5",
+        help="Base text-to-image model ID from Hugging Face.",
+    )
+    parser.add_argument(
+        "--tasks_file",
+        type=str,
+        required=True,
+        help="Path to a .jsonl file with generation tasks.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./generated_images",
+        help="Directory to save the generated images.",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42, help="Random seed for reproducibility."
+    )
+    parser.add_argument("--gpu", type=str, default="0", help="GPU device ID to use.")
+
+    args = parser.parse_args()
+
+    # --- Environment Setup ---
+    os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+    os.environ["CUDA_VISIBLE_DEVICES"] = args.gpu
+    os.makedirs(args.output_dir, exist_ok=True)
+    set_seed(args.seed)
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    # --- Load Pipeline and Attach DrUM ---
+    print(f"Loading base model: {args.model}")
+    pipeline = DiffusionPipeline.from_pretrained(args.model, torch_dtype=dtype).to(
+        device
+    )
+    drum = DrUM(pipeline)
+    print("DrUM attached to pipeline successfully.")
+
+    # --- Process Generation Tasks ---
+    with open(args.tasks_file, "r") as f:
+        tasks = [json.loads(line) for line in f]
+
+    print(f"Found {len(tasks)} tasks. Starting image generation...")
+    for task in tqdm(tasks, desc="Generating Images"):
+        prompt = task.get("prompt")
+        ref = task.get("ref")
+        image_id = task.get("id")
+        alpha = task.get("alpha", 0.3)
+        weight = task.get("weight", [1.0] * len(ref))
+
+        if not all([prompt, ref, image_id]):
+            print(f"Skipping invalid task: {task}")
+            continue
+
+        # Generate personalized image
+        try:
+            images = drum(prompt=prompt, ref=ref, weight=weight, alpha=alpha)
+
+            # Save the image
+            output_path = os.path.join(args.output_dir, f"{image_id}.png")
+            images[0].save(output_path)
+
+        except Exception as e:
+            print(f"Failed to generate image for task {image_id}: {e}")
+
+    print(f"Image generation complete. Images saved to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates DrUM, a personalized text-to-image generation model, into the VQASynth pipeline as a new, preliminary data synthesis stage. Currently, VQASynth processes existing image datasets to create VQA training data. This new feature allows for the programmatic generation of source images, providing greater control over scene composition, style, and content complexity.

The core idea from the DrUM source is its ability to blend a content prompt with a reference (style/concept) prompt without fine-tuning the base diffusion model. By adding a script that leverages this capability, we can generate a diverse and targeted set of images specifically designed to test and improve spatial reasoning. For example, we can create novel scenes with specific object relationships ('a cup behind a book') in various styles ('in the style of a detailed architect's render') that may be rare in standard datasets.

This self-contained script is designed as an initial experimental stage for the VQASynth pipeline. It reads a batch of generation tasks from a JSONL file and outputs the synthesized images, which can then be fed into the existing depth estimation and object detection stages of VQASynth. This approach serves as a form of generative data augmentation at the very beginning of the data creation process.


### Test Strategy
- 1. Prepare a Docker environment that includes Python, PyTorch, Diffusers, and the DrUM library, as specified in the SOURCE_DOCKERFILE.
- 2. Create a `tasks.jsonl` file with several entries, e.g., `{"id": "scene001", "prompt": "a photo of a red ball on a blue box", "ref": ["highly detailed 4k photorealistic"], "alpha": 0.4}`.
- 3. Run the script from the command line: `python experiments/drum_synthesis/run.py --tasks_file tasks.jsonl --output_dir ./output_images`.
- 4. Verify that `.png` files corresponding to the `id` in `tasks.jsonl` are created in the `./output_images` directory.
- 5. Visually inspect the generated images to confirm they reflect both the 'prompt' and 'ref' descriptions.


### Success Criteria
- The script successfully executes and generates an image for each valid task in the input file.
- The generated images exhibit the content specified in the `prompt` and the style/attributes from the `ref` prompt.
- The output images are saved in a standard format (e.g., PNG) and can be processed by the subsequent stages of the VQASynth pipeline (e.g., depth estimation).


**Labels:** data-synthesis

---
**Source:** https://github.com/Burf/DrUM
**Evidence:**
- `README.md`
- `inference.py`

**Experiment metadata:**
- experiment_id: local-1755116158
- run_id: run-1
- paper_id: 2508.03481v1
