### PR TITLE
Feat: Add simulator for ground-truth VQA data generation

### DIFF
--- a/experiments/sim_data_gen/run.py
+++ b/experiments/sim_data_gen/run.py
@@ -1,0 +1,88 @@
+import os
+import json
+import numpy as np
+import cv2
+import gymnasium as gym
+
+# This script leverages the pre-built environments from the RoboManipBaselines repository.
+# To run this, you must first install its dependencies.
+# The SOURCE repo (RoboManipBaselines) provides a rich set of simulated environments
+# that are perfect for generating ground-truth data for VQASynth.
+# We will use the 'MujocoUR5eCableEnv' as it's a well-defined task.
+
+# Ensure the necessary package from the source repo is available
+try:
+    from robo_manip_baselines.envs.mujoco.ur5e import MujocoUR5eCableEnv
+except ImportError:
+    print("Error: 'robo_manip_baselines' is not installed.")
+    print(
+        "Please install it, e.g., via 'pip install git+https://github.com/isri-aist/RoboManipBaselines.git'"
+    )
+    exit(1)
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """Custom JSON encoder for numpy types"""
+
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
+
+
+def generate_simulation_data(output_dir="output/sim_dataset", num_frames=1):
+    """
+    Initializes a MuJoCo environment from RoboManipBaselines, captures observation data,
+    and saves the image and ground-truth state to disk.
+
+    Args:
+        output_dir (str): Directory to save the generated data.
+        num_frames (int): Number of frames/observations to capture.
+    """
+    print("Initializing MuJoCo environment: MujocoUR5eCable-v0")
+
+    # The environment is instantiated just like any Gymnasium environment.
+    # 'render_mode="rgb_array"' is crucial for capturing images without a display.
+    env = gym.make("MujocoUR5eCable-v0", render_mode="rgb_array")
+
+    print("Resetting environment...")
+    obs, _ = env.reset()
+
+    os.makedirs(output_dir, exist_ok=True)
+    print(f"Saving data to {output_dir}")
+
+    for i in range(num_frames):
+        if i > 0:
+            # Take a random action to get a different state
+            action = env.action_space.sample()
+            obs, _, _, _, _ = env.step(action)
+
+        # The observation 'obs' is a dictionary containing the full environment state.
+        # It includes the camera image and ground-truth simulation data like joint positions ('qpos').
+        # This is the key insight: we get perfect 3D data aligned with 2D images.
+        image = obs["image"]
+
+        # The rest of the observation is the ground-truth state vector.
+        # We separate the image for saving as a PNG and serialize the rest as JSON.
+        state_data = {key: value for key, value in obs.items() if key != "image"}
+
+        frame_id = f"frame_{i:03d}"
+        image_path = os.path.join(output_dir, f"{frame_id}.png")
+        json_path = os.path.join(output_dir, f"{frame_id}.json")
+
+        # Save the image (OpenCV expects BGR, but env provides RGB, so we convert)
+        cv2.imwrite(image_path, cv2.cvtColor(image, cv2.COLOR_RGB2BGR))
+
+        # Save the ground-truth state data
+        with open(json_path, "w") as f:
+            json.dump(state_data, f, cls=NumpyEncoder, indent=4)
+
+        print(f"- Saved {image_path} and {json_path}")
+
+    env.close()
+    print("\nData generation complete.")
+    print("This data can now be used as input for a VQASynth pipeline stage.")
+
+
+if __name__ == "__main__":
+    generate_simulation_data(num_frames=1)


### PR DESCRIPTION
This experiment integrates a robotics simulator from the SOURCE repo (RoboManipBaselines) into the TARGET repo (experimental-vqasynth) to serve as a high-fidelity data source. The VQASynth pipeline currently relies on potentially noisy monocular depth estimation models to generate spatial VQA data. By leveraging a simulated MuJoCo environment, we can extract perfect, ground-truth 3D world state (e.g., object coordinates, robot joint states) alongside corresponding rendered 2D images.

This provides a foundation for creating a more accurate and reliable spatial reasoning dataset. The proposed script initializes a `MujocoUR5eCableEnv` environment, captures an observation, and saves the image and its associated ground-truth state data. This demonstrates a proof-of-concept for a data generation pipeline that replaces estimated 3D information with precise simulator ground truth, directly addressing the VQASynth goal of improving spatial awareness in VLMs by providing higher quality training data.

Future work could expand this into a full data generation pipeline that runs diverse scenarios in the simulator and automatically formats the output into templated VQA pairs, ready for fine-tuning a VLM.


### Test Strategy
- Build a Docker container with Python 3.8+ and necessary system libraries for MuJoCo (e.g., `libosmesa6-dev`, `libgl1-mesa-glx`, `libglfw3`).
- Clone the `experimental-vqasynth` repository and check out this feature branch.
- Install Python dependencies: `pip install opencv-python-headless 'robo_manip_baselines[act] @ git+https://github.com/isri-aist/RoboManipBaselines.git'`.
- Run the script from the repository root: `python experiments/sim_data_gen/run.py`.


### Success Criteria
- The script executes without any errors.
- An `output/sim_dataset` directory is created.
- The directory contains `frame_000.png` and `frame_000.json` files.
- The generated PNG file is a valid image showing a view of the MuJoCo simulation environment.
- The generated JSON file contains key-value pairs corresponding to the simulator's ground-truth state, such as `qpos` and `qvel`, with lists of numbers as values.


**Labels:** data-synthesis, robotics, simulation

---
**Source:** https://github.com/isri-aist/RoboManipBaselines
**Evidence:**
- `robo_manip_baselines/envs/mujoco/ur5e/MujocoUR5eCableEnv.py`
- `robo_manip_baselines/common/base/DatasetBase.py`
- `robo_manip_baselines/common/data/DataKey.py`
- `pyproject.toml`

**Experiment metadata:**
- experiment_id: local-1755116158
- run_id: run-1
- paper_id: 2508.08748v1
