### PR TITLE
Feat: Add experiment for model calibration with temperature scaling

### DIFF
--- a/experiments/model-calibration/run.py
+++ b/experiments/model-calibration/run.py
@@ -1,0 +1,195 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Inspired by calibration_tester.py from the SOURCE repo, this script demonstrates
+# temperature scaling to improve model calibration. In VQASynth, this could be
+# applied to models that filter or classify generated data to ensure that their
+# confidence scores are reliable, improving the quality of the final VQA dataset.
+
+
+class SimpleClassifier(nn.Module):
+    """A simple model to generate logits for our calibration demo."""
+
+    def __init__(self, input_size, num_classes):
+        super(SimpleClassifier, self).__init__()
+        self.layer1 = nn.Linear(input_size, 50)
+        self.relu = nn.ReLU()
+        self.layer2 = nn.Linear(50, num_classes)
+
+    def forward(self, x):
+        return self.layer2(self.relu(self.layer1(x)))
+
+
+def generate_dummy_data(n_samples=1000, input_size=10, num_classes=2):
+    """Generates synthetic logits and labels.
+    We'll intentionally create a slightly miscalibrated model by training briefly.
+    """
+    model = SimpleClassifier(input_size, num_classes)
+    # Intentionally make the model overconfident by using a simple dataset
+    features = torch.randn(n_samples, input_size)
+    # Create labels that are mostly correct but have some noise
+    true_weights = torch.randn(input_size, num_classes)
+    true_bias = torch.randn(num_classes)
+    logits = features @ true_weights + true_bias
+    labels = torch.argmax(logits, dim=1)
+    # Add some label noise to prevent perfect separation and encourage overconfidence
+    noise_mask = torch.rand(n_samples) < 0.15
+    labels[noise_mask] = 1 - labels[noise_mask]
+
+    # Briefly train the model to get some reasonable but not perfectly calibrated logits
+    optimizer = optim.Adam(model.parameters(), lr=0.01)
+    loss_fn = nn.CrossEntropyLoss()
+    for _ in range(20):
+        optimizer.zero_grad()
+        out_logits = model(features)
+        loss = loss_fn(out_logits, labels)
+        loss.backward()
+        optimizer.step()
+
+    # Get the final logits on the "validation" data (the same data here for simplicity)
+    with torch.no_grad():
+        final_logits = model(features)
+
+    return final_logits, labels
+
+
+class ModelWithTemperature(nn.Module):
+    """
+    A thin wrapper for a model to apply temperature scaling.
+    This is the core idea from SOURCE's calibration_tester.py.
+    """
+
+    def __init__(self, model):
+        super(ModelWithTemperature, self).__init__()
+        self.model = model
+        self.temperature = nn.Parameter(torch.ones(1) * 1.5)
+
+    def forward(self, x):
+        logits = self.model(x)
+        return self.temperature_scale(logits)
+
+    def temperature_scale(self, logits):
+        # The key operation: dividing logits by the temperature.
+        return logits / self.temperature
+
+
+def find_optimal_temperature(logits, labels):
+    """
+    Find the optimal temperature T by minimizing NLL on a validation set.
+    """
+    nll_criterion = nn.CrossEntropyLoss()
+    # Initial temperature
+    temperature = nn.Parameter(torch.ones(1) * 1.0)
+    optimizer = optim.LBFGS([temperature], lr=0.01, max_iter=50)
+
+    def eval():
+        optimizer.zero_grad()
+        loss = nll_criterion(logits / temperature, labels)
+        loss.backward()
+        return loss
+
+    optimizer.step(eval)
+    return temperature.item()
+
+
+def calculate_ece(probs, labels, n_bins=15):
+    """
+    Calculates the Expected Calibration Error of a model.
+    """
+    bin_boundaries = torch.linspace(0, 1, n_bins + 1)
+    bin_lowers = bin_boundaries[:-1]
+    bin_uppers = bin_boundaries[1:]
+
+    confidences, predictions = torch.max(probs, 1)
+    accuracies = predictions.eq(labels)
+
+    ece = torch.zeros(1)
+    for bin_lower, bin_upper in zip(bin_lowers, bin_uppers):
+        in_bin = confidences.gt(bin_lower.item()) * confidences.le(bin_upper.item())
+        prop_in_bin = in_bin.float().mean()
+        if prop_in_bin.item() > 0:
+            accuracy_in_bin = accuracies[in_bin].float().mean()
+            avg_confidence_in_bin = confidences[in_bin].mean()
+            ece += torch.abs(avg_confidence_in_bin - accuracy_in_bin) * prop_in_bin
+
+    return ece.item()
+
+
+def plot_reliability_diagram(uncal_probs, cal_probs, labels, n_bins=15):
+    """Plots a reliability diagram to visualize calibration."""
+    bin_boundaries = torch.linspace(0, 1, n_bins + 1)
+    bin_centers = (bin_boundaries[:-1] + bin_boundaries[1:]) / 2
+
+    def get_bin_accuracies(probs):
+        accuracies = []
+        confidences = []
+        for i in range(n_bins):
+            bin_lower = bin_boundaries[i]
+            bin_upper = bin_boundaries[i + 1]
+            in_bin = (probs.max(1)[0] > bin_lower) & (probs.max(1)[0] <= bin_upper)
+            if in_bin.sum() > 0:
+                bin_acc = (probs.argmax(1)[in_bin] == labels[in_bin]).float().mean()
+                bin_conf = probs.max(1)[0][in_bin].mean()
+                accuracies.append(bin_acc.item())
+                confidences.append(bin_conf.item())
+            else:
+                accuracies.append(0)
+                confidences.append(0)  # or nan
+        return accuracies, confidences
+
+    uncal_accs, _ = get_bin_accuracies(uncal_probs)
+    cal_accs, _ = get_bin_accuracies(cal_probs)
+
+    plt.figure(figsize=(8, 8))
+    plt.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect Calibration")
+    plt.plot(
+        bin_centers,
+        uncal_accs,
+        marker="o",
+        linestyle="-",
+        color="blue",
+        label="Uncalibrated Model",
+    )
+    plt.plot(
+        bin_centers,
+        cal_accs,
+        marker="s",
+        linestyle="-",
+        color="red",
+        label="Calibrated Model (Temp. Scaling)",
+    )
+    plt.xlabel("Confidence")
+    plt.ylabel("Accuracy")
+    plt.title("Reliability Diagram")
+    plt.legend()
+    plt.grid(True)
+    plt.savefig("reliability_diagram.png")
+    print("Saved reliability diagram to reliability_diagram.png")
+
+
+if __name__ == "__main__":
+    print("Generating dummy data and an overconfident model...")
+    val_logits, val_labels = generate_dummy_data(n_samples=2000)
+
+    # Get uncalibrated probabilities and ECE
+    uncalibrated_probs = torch.softmax(val_logits, dim=1)
+    ece_before = calculate_ece(uncalibrated_probs, val_labels)
+    print(f"ECE before calibration: {ece_before:.4f}")
+
+    # Find optimal temperature
+    print("Finding optimal temperature...")
+    optimal_t = find_optimal_temperature(val_logits, val_labels)
+    print(f"Optimal temperature found: {optimal_t:.3f}")
+
+    # Apply temperature and get calibrated probabilities and ECE
+    calibrated_logits = val_logits / optimal_t
+    calibrated_probs = torch.softmax(calibrated_logits, dim=1)
+    ece_after = calculate_ece(calibrated_probs, val_labels)
+    print(f"ECE after calibration: {ece_after:.4f}")
+
+    # Plotting results
+    print("Generating reliability diagram...")
+    plot_reliability_diagram(uncalibrated_probs, calibrated_probs, val_labels)


### PR DESCRIPTION
This experiment integrates the concept of model calibration via temperature scaling, a technique prominently featured in the SOURCE repository for improving the reliability of a wireless outage classifier. In the context of the TARGET VQASynth pipeline, models are used to generate and filter synthetic data. The confidence scores of these models are crucial; a poorly calibrated (e.g., overconfident) model can introduce noisy or incorrect samples into the final training dataset, which can degrade the performance of the fine-tuned Vision Language Model.

Inspired by `calibration_tester.py` from the SOURCE repo, this branch introduces a self-contained PyTorch-based experiment that demonstrates how to find an optimal temperature for scaling model logits. The script calculates the Expected Calibration Error (ECE) before and after scaling and generates a reliability diagram to visualize the improvement.

This provides a practical, testable blueprint for how calibration could be integrated into the VQASynth pipeline's quality control stages (e.g., the filter stage). By ensuring that the models used for data generation have reliable confidence estimates, we can enhance the quality and correctness of the synthetic VQA dataset, leading to more robust and accurate VLMs.


### Test Strategy
- Build a Docker image using a base that includes PyTorch, NumPy, and Matplotlib. The TARGET repo's `docker/base_image/Dockerfile` can be adapted for this.
- Run the experiment script within the container: `python experiments/model-calibration/run.py`.
- Check the standard output for the printed ECE values before and after calibration.
- Verify that a `reliability_diagram.png` file is created in the current directory.


### Success Criteria
- The script executes without any errors.
- The printed 'ECE after calibration' value is measurably lower than the 'ECE before calibration' value.
- The generated `reliability_diagram.png` shows the 'Calibrated Model' line is visibly closer to the diagonal 'Perfect Calibration' line than the 'Uncalibrated Model' line.


**Labels:** inference-optimization, data-synthesis, experiment

---
**Source:** https://github.com/ML4Comms/greedy-resource-allocation-outage-classification
**Evidence:**
- `calibration_tester.py`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2507.17494v1
