### PR TITLE
feat: Add Memory-Gym for sequential VQA data generation

### DIFF
--- a/experiments/memory_gym_data_gen/run.py
+++ b/experiments/memory_gym_data_gen/run.py
@@ -1,0 +1,92 @@
+import gymnasium as gym
+import memory_gym
+import os
+import json
+import numpy as np
+from PIL import Image
+
+
+def generate_episode_data(env_name="MortarMayhem-v0", output_dir="episode_data"):
+    """
+    Runs one episode of a memory_gym environment and saves observations and metadata.
+    """
+    print(f"Initializing environment: {env_name}")
+    # The environment returns rgb_array observations by default
+    env = gym.make(env_name)
+
+    # Create output directory
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    frames_dir = os.path.join(output_dir, "frames")
+    if not os.path.exists(frames_dir):
+        os.makedirs(frames_dir)
+
+    print(f"Resetting environment and starting episode...")
+    obs, info = env.reset(seed=42)
+
+    done = False
+    truncated = False
+    step_count = 0
+    metadata = []
+
+    # Save initial observation
+    img = Image.fromarray(obs)
+    img.save(os.path.join(frames_dir, f"frame_{step_count:04d}.png"))
+    metadata.append(info)
+
+    while not done and not truncated:
+        action = env.action_space.sample()  # Use a random agent for now
+        obs, reward, done, truncated, info = env.step(action)
+        step_count += 1
+
+        # Save frame as PNG
+        img = Image.fromarray(obs)
+        img.save(os.path.join(frames_dir, f"frame_{step_count:04d}.png"))
+
+        # Convert numpy types in info for JSON serialization
+        serializable_info = {}
+        for k, v in info.items():
+            if isinstance(v, np.ndarray):
+                serializable_info[k] = v.tolist()
+            elif isinstance(
+                v,
+                (
+                    np.int_,
+                    np.intc,
+                    np.intp,
+                    np.int8,
+                    np.int16,
+                    np.int32,
+                    np.int64,
+                    np.uint8,
+                    np.uint16,
+                    np.uint32,
+                    np.uint64,
+                ),
+            ):
+                serializable_info[k] = int(v)
+            elif isinstance(v, (np.float_, np.float16, np.float32, np.float64)):
+                serializable_info[k] = float(v)
+            else:
+                serializable_info[k] = v
+        metadata.append(serializable_info)
+
+        if (step_count) % 50 == 0:
+            print(f"  ... step {step_count}")
+
+    env.close()
+
+    # Save metadata
+    metadata_path = os.path.join(output_dir, "metadata.json")
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    print(f"\nEpisode finished after {step_count} steps.")
+    print(f"Data saved to {output_dir}")
+    print(f"  - Frames: {frames_dir}")
+    print(f"  - Metadata: {metadata_path}")
+
+
+if __name__ == "__main__":
+    generate_episode_data()


### PR DESCRIPTION
The VQASynth pipeline currently excels at generating spatial reasoning VQA datasets from static images. This provides a strong foundation for teaching VLMs about object relationships in a fixed scene. However, many embodied AI tasks require reasoning about state changes, actions, and sequences over time—a capability this experiment aims to explore.

The SOURCE repository, 'endless-memory-gym', provides a suite of partially observable, dynamic environments designed to benchmark agent memory. Specifically, the 'Mortar Mayhem' environment challenges an agent to memorize a sequence of visual commands and then execute them in the correct order. This setup is an ideal source for generating data that tests procedural and temporal understanding.

This feature branch introduces a preliminary data generation script that runs a 'Mortar Mayhem' episode and systematically saves all visual observations and corresponding ground-truth metadata. This captured data, containing a complete record of a sequential task, can be used as a novel input source for the VQASynth pipeline. The goal is to later generate VQA pairs that query the model on action sequences, memory recall, and cause-and-effect, thereby extending its spatial reasoning abilities into the temporal domain.


### Test Strategy
- Build a Docker container from an appropriate base image (e.g., `pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel`).
- Inside the Dockerfile, add the following installation commands: `RUN apt-get update && apt-get install -y libgl1-mesa-glx` and `RUN pip install memory-gym gymnasium==0.29.0 pygame==2.4.0 numpy Pillow`.
- Copy the new script into the container and run it: `python experiments/memory_gym_data_gen/run.py`.
- Verify that an `episode_data/` directory is created in the current working directory.
- Inspect the `episode_data/` directory to confirm the presence of a `frames/` subdirectory with multiple PNG files and a `metadata.json` file.


### Success Criteria
- The script executes without raising any exceptions.
- An `episode_data` directory is generated containing a sequence of PNG image frames from a `MortarMayhem-v0` episode.
- A `metadata.json` file is created, containing a JSON array with ground-truth information for each step of the episode, such as agent position and command sequence status.


**Labels:** data-synthesis, experiment

---
**Source:** https://github.com/MarcoMeter/endless-memory-gym
**Evidence:**
- `README.md`
- `memory_gym/mortar_mayhem.py`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2507.22010v1
