### PR TITLE
Feat: Add Reasoning Step Reward Model for CoT Evaluation

### DIFF
--- a/docker/reasoning_reward_stage/Dockerfile
+++ b/docker/reasoning_reward_stage/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.4
+
+# Use a base image with PyTorch and CUDA
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+
+WORKDIR /app
+
+# Install git and other essentials
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+RUN pip install --no-cache-dir transformers==4.40.1 accelerate==0.29.3 sentencepiece==0.2.0
+
+# Copy the processing script and entrypoint
+COPY process_reasoning_rewards.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/reasoning_reward_stage/entrypoint.sh
+++ b/docker/reasoning_reward_stage/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Expects environment variables to be set by docker run command
+# - INPUT_PATH: Path to the input JSONL file inside the container
+# - OUTPUT_PATH: Path to write the output JSONL file inside the container
+# - CQT_FIELD: The key in the JSON object that contains the CoT string.
+# - QUESTION_FIELD: The key in the JSON object that contains the question string.
+
+# Default values
+MODEL_ID_PRM=${MODEL_ID_PRM:="UW-Madison-Lee-Lab/VersaPRM"}
+BATCH_SIZE=${BATCH_SIZE:=8}
+
+echo "Starting reasoning reward processing..."
+
+python process_reasoning_rewards.py \
+    --input_path "${INPUT_PATH}" \
+    --output_path "${OUTPUT_PATH}" \
+    --cot_field "${COT_FIELD}" \
+    --question_field "${QUESTION_FIELD}" \
+    --model_id_prm "${MODEL_ID_PRM}" \
+    --batch_size "${BATCH_SIZE}"
+
+echo "Reasoning reward processing complete. Output at ${OUTPUT_PATH}"

--- a/docker/reasoning_reward_stage/process_reasoning_rewards.py
+++ b/docker/reasoning_reward_stage/process_reasoning_rewards.py
@@ -1,0 +1,159 @@
+import argparse
+import json
+import torch
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+from tqdm import tqdm
+import re
+
+def_tokenizer = None
+def_model = None
+
+
+def get_prm_reward(prm_model, prm_tokenizer, questions, steps):
+    """Calculates the reward for a given list of question-step pairs."""
+    inputs = prm_tokenizer(
+        questions,
+        steps,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=1024,
+    ).to(prm_model.device)
+    with torch.no_grad():
+        logits = prm_model(**inputs).logits
+        rewards = torch.squeeze(logits)
+    return rewards.cpu().tolist()
+
+
+def split_reasoning(text):
+    """Splits the reasoning chain into steps based on newlines or sentence-ending punctuation."""
+    # First, try splitting by newline, which is a common CoT step delimiter
+    steps = [s.strip() for s in text.split("\n") if s.strip()]
+    if len(steps) > 1:
+        return steps
+
+    # If newline splitting fails, fall back to sentence-based splitting
+    # This regex splits by '.', '?', '!' followed by a space or end of string
+    sentences = re.split(r"(?<=[.?!])\s+", text.strip())
+    return [s.strip() for s in sentences if s.strip()]
+
+
+def process_batch(batch, args, prm_model, prm_tokenizer):
+    """Processes a batch of data to add reasoning rewards."""
+    questions_batch = []
+    steps_batch = []
+    indices_map = []
+
+    for i, item in enumerate(batch):
+        question = item.get(args.question_field, "")
+        cot_text = item.get(args.cot_field, "")
+        if not cot_text:
+            item["reasoning_steps"] = []
+            item["reasoning_step_scores"] = []
+            continue
+
+        steps = split_reasoning(cot_text)
+        item["reasoning_steps"] = steps
+        if not steps:
+            item["reasoning_step_scores"] = []
+            continue
+
+        for step in steps:
+            questions_batch.append(question)
+            steps_batch.append(step)
+        indices_map.append(len(steps))
+
+    if not questions_batch:
+        return batch
+
+    rewards = get_prm_reward(prm_model, prm_tokenizer, questions_batch, steps_batch)
+
+    # Handle case where only one reward is returned
+    if not isinstance(rewards, list):
+        rewards = [rewards]
+
+    current_pos = 0
+    for i, num_steps in enumerate(indices_map):
+        if num_steps > 0:
+            batch[i]["reasoning_step_scores"] = rewards[
+                current_pos : current_pos + num_steps
+            ]
+            current_pos += num_steps
+        else:
+            batch[i]["reasoning_step_scores"] = []
+
+    return batch
+
+
+def main(args):
+    print(f"Loading PRM model: {args.model_id_prm}")
+    prm_tokenizer = AutoTokenizer.from_pretrained(args.model_id_prm)
+    prm_model = AutoModelForSequenceClassification.from_pretrained(
+        args.model_id_prm, torch_dtype=torch.bfloat16
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    prm_model.to(device)
+    prm_model.eval()
+    print(f"Model loaded on {device}")
+
+    with open(args.input_path, "r") as f_in, open(args.output_path, "w") as f_out:
+        lines = f_in.readlines()
+        batch = []
+        for line in tqdm(lines, desc="Processing data"):
+            try:
+                batch.append(json.loads(line))
+            except json.JSONDecodeError:
+                print(f"Skipping malformed JSON line: {line.strip()}")
+                continue
+
+            if len(batch) >= args.batch_size:
+                processed_batch = process_batch(batch, args, prm_model, prm_tokenizer)
+                for item in processed_batch:
+                    f_out.write(json.dumps(item) + "\n")
+                batch = []
+
+        # Process the final batch
+        if batch:
+            processed_batch = process_batch(batch, args, prm_model, prm_tokenizer)
+            for item in processed_batch:
+                f_out.write(json.dumps(item) + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Score reasoning steps in model outputs using a Process Reward Model."
+    )
+    parser.add_argument(
+        "--input_path", type=str, required=True, help="Path to the input JSONL file."
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Path to write the output JSONL file.",
+    )
+    parser.add_argument(
+        "--cot_field",
+        type=str,
+        required=True,
+        help="The key in the JSON object that contains the CoT string.",
+    )
+    parser.add_argument(
+        "--question_field",
+        type=str,
+        required=True,
+        help="The key in the JSON object that contains the question.",
+    )
+    parser.add_argument(
+        "--model_id_prm",
+        type=str,
+        default="UW-Madison-Lee-Lab/VersaPRM",
+        help="The model ID for the Process Reward Model.",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=8, help="Batch size for processing."
+    )
+
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
This experiment integrates a core concept from the STIM repository—diagnosing chain-of-thought (CoT) reasoning—into the VQASynth pipeline. The STIM paper introduces a framework for identifying memorization and errors at a token level, starting with a Process Reward Model (PRM) to score the correctness of each reasoning step. VQASynth focuses on generating high-quality synthetic VQA data to teach VLMs spatial reasoning, often employing CoT. However, it lacks a mechanism to evaluate the quality of the generated reasoning chains themselves, beyond final answer correctness.

This feature branch introduces a new, optional analysis stage to the VQASynth Docker pipeline: `reasoning_reward_stage`. This stage adapts STIM's `get_reward.py` script to score the step-by-step reasoning generated by a model fine-tuned on VQASynth data. It uses a pre-trained Process Reward Model to assign a score to each sentence in the model's CoT output, identifying potential logical fallacies, factual inaccuracies, or nonsensical steps.

By adding this diagnostic tool, we can gain deeper insights into how models are learning from the synthetic data. This allows for more targeted improvements to the VQASynth data generation templates and the fine-tuning process. It directly applies STIM's analytical rigor to VQASynth's generative goals, creating a feedback loop for producing models with more robust and verifiable reasoning abilities.


### Test Strategy
- 1. Create a sample `input.jsonl` file with a few VQA examples, each containing a 'question' field and a 'model_cot_response' field with multi-sentence reasoning.
- 2. Build the Docker image: `docker build -t reasoning-reward-stage ./docker/reasoning_reward_stage/`.
- 3. Run the Docker container, mounting the input file and an output directory, and setting the required environment variables: `docker run --gpus all -v $(pwd)/test_data:/data -e INPUT_PATH=/data/input.jsonl -e OUTPUT_PATH=/data/output.jsonl -e COT_FIELD=model_cot_response -e QUESTION_FIELD=question reasoning-reward-stage`.
- 4. Verify that the container runs successfully and creates `output.jsonl` in the test directory.
- 5. Inspect the `output.jsonl` file to confirm that each JSON object now contains two new keys: `reasoning_steps` (a list of strings) and `reasoning_step_scores` (a list of floats), and that the number of elements in both lists is equal.


### Success Criteria
- The Docker container executes the `process_reasoning_rewards.py` script to completion without errors.
- The output JSONL file is created and contains the same number of lines as the input file.
- Each line in the output file is valid JSON and includes the original data plus the `reasoning_steps` and `reasoning_step_scores` fields.
- The `reasoning_step_scores` list contains float values, representing the reward for each corresponding step in the `reasoning_steps` list.


**Labels:** experiment, interpretability, evaluation, chain-of-thought

---
**Source:** https://github.com/INK-USC/STIM
**Evidence:**
- `README.md`
- `src/get_reward.py`
- `src/get_reward.sh`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2508.02037v1
