### PR TITLE
feat(train): Integrate CLIPin non-contrastive loss into VLM training

### DIFF
--- a/docker/llava_train/clipin.py
+++ b/docker/llava_train/clipin.py
@@ -1,0 +1,70 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Projector(nn.Module):
+    """
+    Simple MLP projector for mapping features to a new latent space.
+    As described in CLIPin, this is an additional projection head.
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+
+
+class CLIPinLoss(nn.Module):
+    """
+    A non-contrastive loss to enforce semantic alignment between paired
+    image and text embeddings, inspired by T6Yang/CLIPin.
+
+    This implementation uses a Mean Squared Error (MSE) loss on the L2-normalized
+    outputs of two separate projection heads. This encourages the representations
+    of a correct image-text pair to be identical in the projected space.
+    """
+
+    def __init__(self, embedding_dim: int, projection_dim: int = 512):
+        super().__init__()
+        # Projectors for image and text features
+        self.image_projector = Projector(
+            embedding_dim, embedding_dim * 2, projection_dim
+        )
+        self.text_projector = Projector(
+            embedding_dim, embedding_dim * 2, projection_dim
+        )
+
+    def forward(
+        self, image_features: torch.Tensor, text_features: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Calculates the non-contrastive alignment loss.
+
+        Args:
+            image_features: A tensor of image features from the vision encoder.
+                            Shape: (batch_size, embedding_dim)
+            text_features: A tensor of text features (e.g., from the [CLS] token
+                           or mean-pooled last hidden state of the text encoder).
+                           Shape: (batch_size, embedding_dim)
+
+        Returns:
+            The calculated CLIPin loss value.
+        """
+        # Project features into a new space
+        image_projection = self.image_projector(image_features)
+        text_projection = self.text_projector(text_features)
+
+        # Normalize the projected features to prevent collapse and focus on cosine similarity
+        image_projection = F.normalize(image_projection, p=2, dim=1)
+        text_projection = F.normalize(text_projection, p=2, dim=1)
+
+        # Calculate MSE loss between the normalized projections
+        loss = F.mse_loss(image_projection, text_projection)
+        return loss

--- a/docker/llava_train/train_with_clipin.py
+++ b/docker/llava_train/train_with_clipin.py
@@ -1,0 +1,94 @@
+import torch
+from transformers import AutoProcessor, LlavaForConditionalGeneration
+from clipin import CLIPinLoss
+import os
+
+# This is a simplified, illustrative training script.
+# It demonstrates how to integrate the CLIPinLoss into a typical VLM
+# fine-tuning loop. It assumes a pre-processed dataset is available.
+
+
+def main():
+    # --- 1. Setup Model, Processor, and CLIPin Loss ---
+    print("Loading model and processor...")
+    # Using a standard model for demonstration
+    model_id = "llava-hf/llava-1.5-7b-hf"
+    model = LlavaForConditionalGeneration.from_pretrained(
+        model_id, torch_dtype=torch.float16, low_cpu_mem_usage=True
+    )
+    processor = AutoProcessor.from_pretrained(model_id)
+
+    # Move model to device
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device)
+
+    # Initialize the CLIPin loss module
+    # LLaVA's vision tower (CLIP) uses an embedding dim of 1024 for ViT-L/14
+    clip_embedding_dim = model.config.vision_config.hidden_size
+    clipin_loss_fn = CLIPinLoss(embedding_dim=clip_embedding_dim).to(device)
+    print(f"CLIPinLoss initialized for embedding dimension: {clip_embedding_dim}")
+
+    # --- 2. Setup Optimizer ---
+    # In a real scenario, this would only include LoRA adapter parameters and the new projectors.
+    trainable_params = list(model.parameters()) + list(clipin_loss_fn.parameters())
+    optimizer = torch.optim.AdamW(trainable_params, lr=1e-5)
+
+    # --- 3. Mock Data and Training Loop ---
+    # In a real scenario, this would come from a torch.utils.data.DataLoader
+    # created from the VQASynth pipeline output.
+    print("Starting mock training loop...")
+    prompt = "<image>\nUSER: What is the spatial relationship between the objects?\nASSISTANT:"
+    answer_text = "The red forklift is to the left of the brown cardboard boxes."
+
+    # Mock image (replace with actual image loading)
+    image = torch.zeros(
+        3, 336, 336, dtype=torch.float16
+    )  # LLaVA 1.5 default resolution
+
+    # Pre-process inputs
+    inputs = processor(text=prompt, images=image, return_tensors="pt").to(
+        device, torch.float16
+    )
+    labels = processor.tokenizer(answer_text, return_tensors="pt").input_ids.to(device)
+
+    model.train()
+    clipin_loss_fn.train()
+
+    # --- 4. Combined Loss Calculation ---
+    # To get vision features, we perform a forward pass through the vision tower.
+    # output_hidden_states=True is required.
+    vision_tower = model.get_vision_tower()
+    image_forward_outs = vision_tower(inputs["pixel_values"], output_hidden_states=True)
+    # Use the penultimate layer's CLS token as the image representation
+    image_features = image_forward_outs.hidden_states[-2][:, 0, :]
+
+    # To get text features, we can use the embeddings of the input prompt.
+    # This is a simplification; a more robust method might align specific tokens.
+    input_ids = inputs["input_ids"]
+    text_features = model.get_input_embeddings()(input_ids).mean(dim=1)
+
+    # Get the standard language modeling loss
+    outputs = model(**inputs, labels=labels)
+    main_loss = outputs.loss
+
+    # Get the auxiliary CLIPin loss
+    aux_loss = clipin_loss_fn(image_features, text_features.to(torch.float16))
+
+    # Combine losses with a weighting factor
+    alpha = 0.1
+    total_loss = main_loss + alpha * aux_loss
+
+    print(
+        f"Main Loss: {main_loss.item():.4f}, CLIPin Loss: {aux_loss.item():.4f}, Total Loss: {total_loss.item():.4f}"
+    )
+
+    # --- 5. Backpropagation and Update ---
+    total_loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+
+    print("Training step complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates the core concept from the SOURCE repository, T6Yang/CLIPin, which proposes a non-contrastive training objective to improve multimodal semantic alignment. This is achieved via an auxiliary loss that encourages paired image and text embeddings to become more similar after passing them through dedicated projection heads, as detailed in the SOURCE `main.py` training loop.

The TARGET repository, experimental-vqasynth, fine-tunes Vision-Language Models (VLMs) for advanced spatial reasoning. Better semantic alignment in the underlying vision encoder is hypothesized to improve these downstream capabilities. By integrating the CLIPin loss into the LoRA fine-tuning stage (`llava_train`), we can explicitly train for this alignment using the image-caption pairs from the VQASynth-generated dataset.

This proposal introduces a `CLIPinLoss` module and an accompanying example training script, `train_with_clipin.py`, into the `llava_train` Docker stage. The script demonstrates how to combine the standard VLM language modeling loss with the auxiliary CLIPin loss during a fine-tuning step. The goal is to test if this combined objective yields a model with improved performance on spatial reasoning benchmarks without requiring architectural changes to the VLM itself.


### Test Strategy
- Build the `llava_train` Docker image using its Dockerfile to include the new `clipin.py` module and `train_with_clipin.py` script.
- Generate a small-scale VQA dataset (e.g., 1k-5k samples) using the preceding VQASynth pipeline stages.
- Run two training experiments using the `llava_train` container: (1) a baseline using a standard LoRA training script, and (2) the proposed experiment using `train_with_clipin.py`.
- Evaluate the resulting LoRA adapters from both experiments on a held-out spatial reasoning benchmark (e.g., a custom test set from the VQASynth pipeline or a public VQA dataset).
- Compare the quantitative benchmark scores between the two models.


### Success Criteria
- The fine-tuning process with the combined language modeling and CLIPin loss converges successfully.
- The model fine-tuned with the CLIPin loss shows a measurable improvement (e.g., >2% increase in accuracy or relevant metric) on the spatial reasoning evaluation benchmark compared to the baseline.
- Qualitative analysis of model outputs shows improved object grounding and more accurate spatial relationship descriptions for the model trained with the auxiliary loss.


**Labels:** experiment, efficient-finetuning, data-synthesis

---
**Source:** https://github.com/T6Yang/CLIPin
**Evidence:**
- `README.md`
- `main.py`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2508.06434v1
