### PR TITLE
Feat: Add utility for experiment reproducibility

### DIFF
--- a/experiments/reproducibility/run.py
+++ b/experiments/reproducibility/run.py
@@ -1,0 +1,76 @@
+import os
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed=42):
+    """
+    Sets the random seeds for deterministic experiments, inspired by the robust
+    experimental setup in the CNSDiff repository.
+
+    Ensures reproducibility across Python's random module, NumPy, and PyTorch
+    (for both CPU and GPU).
+
+    Args:
+        seed (int): The seed value to use.
+    """
+    print(f"Setting all random seeds to {seed} for reproducibility.")
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)  # for multi-GPU.
+        # The following two lines are known to degrade performance but are
+        # essential for true determinism in CUDA operations.
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+
+
+if __name__ == "__main__":
+    """
+    Demonstrates the effect of the set_seed utility. Running this script
+    multiple times should produce the exact same "random" outputs. This is
+    critical for debugging and comparing experiment runs in the VQASynth pipeline.
+    """
+    SEED = 2024
+
+    print("--- Demonstrating Reproducibility ---")
+    set_seed(SEED)
+
+    # Generate a "random" numpy array
+    numpy_random_array = np.random.rand(2, 3)
+    print("\nGenerated NumPy array:")
+    print(numpy_random_array)
+
+    # Generate a "random" torch tensor
+    torch_random_tensor = torch.rand(2, 3)
+    print("\nGenerated PyTorch tensor:")
+    print(torch_random_tensor)
+
+    print("\n--- Rerunning with the same seed ---")
+    set_seed(SEED)
+
+    # Generate another "random" numpy array
+    numpy_random_array_2 = np.random.rand(2, 3)
+    print("\nGenerated NumPy array:")
+    print(numpy_random_array_2)
+
+    # Generate another "random" torch tensor
+    torch_random_tensor_2 = torch.rand(2, 3)
+    print("\nGenerated PyTorch tensor:")
+    print(torch_random_tensor_2)
+
+    # Verify that the outputs were identical
+    assert np.array_equal(numpy_random_array, numpy_random_array_2)
+    assert torch.equal(torch_random_tensor, torch_random_tensor_2)
+
+    print("\nSuccess: Both runs produced identical outputs as expected.")
+    print(
+        "This utility can be integrated into VQASynth data generation and training scripts."
+    )


### PR DESCRIPTION
The CNSDiff source repository emphasizes robust Out-of-Distribution (OOD) evaluation, which relies heavily on reproducible experimental setups. Their `main.py` includes a comprehensive `set_seed` function to ensure determinism across `numpy`, `random`, and `torch`, which is a cornerstone of rigorous machine learning research.

The VQASynth target repository involves a complex, multi-stage pipeline with numerous stochastic elements, from data shuffling to model initializations. Achieving deterministic behavior is critical for debugging, comparing different data generation strategies, and reliably reproducing training outcomes. Without it, it's difficult to ascertain whether a change in performance is due to a methodological improvement or random chance.

This feature branch introduces a standalone experimental script that integrates the `set_seed` utility from CNSDiff. It provides a minimal, self-contained demonstration of how to enforce reproducibility. This utility can be adopted across the various stages of the VQASynth pipeline to improve the overall engineering rigor and reliability of the data synthesis and model fine-tuning processes.


### Test Strategy
- Build a Docker image with Python, PyTorch, and NumPy installed.
- Execute the script within the container: `python experiments/reproducibility/run.py`.
- Capture the output.
- Execute the script a second time and capture the output.
- Compare the output from both runs.


### Success Criteria
- The script runs to completion and prints the 'Success' message.
- The printed NumPy arrays and PyTorch tensors from the first and second runs must be bit-for-bit identical.


**Labels:** experiment, reproducibility

---
**Source:** https://github.com/user683/CNSDiff
**Evidence:**
- `main.py`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2508.07243v1
