### PR TITLE
Feat: Add anxiety perturbation filter to test VLM robustness

### DIFF
--- a/experiments/robustness_test/run_anxiety_filter.py
+++ b/experiments/robustness_test/run_anxiety_filter.py
@@ -1,0 +1,98 @@
+import argparse
+from pathlib import Path
+import numpy as np
+from PIL import Image
+
+
+def apply_anxiety_tunnel_vision(
+    image: Image.Image, severity: float = 0.8
+) -> Image.Image:
+    """
+    Applies a filter to simulate anxiety-induced tunnel vision.
+
+    This effect is achieved by desaturating and darkening the periphery of the image,
+    drawing focus to the center. The severity parameter controls the intensity of the effect.
+    This implementation is inspired by the condition described in the Perceptual Reality
+    Transformer (https://github.com/linlab/prt) paper.
+
+    Args:
+        image (Image.Image): The input PIL image.
+        severity (float): The intensity of the effect, from 0.0 (no effect) to 1.0 (max effect).
+
+    Returns:
+        Image.Image: The perturbed PIL image.
+    """
+    if severity == 0:
+        return image
+
+    width, height = image.size
+    hsv_image = image.convert("HSV")
+    h, s, v = hsv_image.split()
+
+    # Create a radial gradient mask
+    center_x, center_y = width / 2, height / 2
+    y, x = np.ogrid[:height, :width]
+    dist_from_center = np.sqrt((x - center_x) ** 2 + (y - center_y) ** 2)
+
+    # Normalize distance to be 0 at center and 1 at the furthest corner
+    max_dist = np.sqrt(center_x**2 + center_y**2)
+    normalized_dist = dist_from_center / max_dist
+
+    # Invert the gradient: 1 at the center, falling off to 0
+    focus_mask = 1 - normalized_dist
+
+    # Apply severity scaling to control the size of the focused area and sharpness of falloff
+    focus_mask = np.clip(focus_mask * (2.0 - severity * 1.5), 0, 1)
+
+    # Convert numpy mask to PIL Image for blending
+    mask_s = Image.fromarray((focus_mask * 255).astype(np.uint8))
+    mask_v = Image.fromarray((focus_mask * 255).astype(np.uint8))
+
+    # Create fully desaturated and darkened layers for blending
+    s_desaturated = Image.new("L", (width, height), 0)
+    v_darkened = Image.new("L", (width, height), 0)
+
+    # Composite the original saturation/value with the modified versions using the mask
+    s_final = Image.composite(s, s_desaturated, mask_s)
+    v_final = Image.composite(v, v_darkened, mask_v)
+
+    final_hsv = Image.merge("HSV", (h, s_final, v_final))
+    return final_hsv.convert("RGB")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Apply a perceptual anxiety/tunnel vision filter to an image. "
+        "Inspired by linlab/prt to test VLM robustness."
+    )
+    parser.add_argument("input_path", type=Path, help="Path to the input image.")
+    parser.add_argument(
+        "output_path", type=Path, help="Path to save the processed image."
+    )
+    parser.add_argument(
+        "--severity",
+        type=float,
+        default=0.8,
+        help="Severity of the tunnel vision effect (0.0 to 1.0).",
+    )
+
+    args = parser.parse_args()
+
+    if not args.input_path.is_file():
+        raise FileNotFoundError(f"Input file not found at {args.input_path}")
+
+    args.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading image from: {args.input_path}")
+    original_image = Image.open(args.input_path).convert("RGB")
+
+    print(f"Applying anxiety tunnel vision filter with severity {args.severity}...")
+    perturbed_image = apply_anxiety_tunnel_vision(original_image, args.severity)
+
+    print(f"Saving perturbed image to: {args.output_path}")
+    perturbed_image.save(args.output_path)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates concepts from the Perceptual Reality Transformer (PRT) from `linlab/prt` into the VQASynth pipeline. The PRT project simulates various neurological perception conditions to foster empathy and understanding. We adapt this idea not for human empathy, but for machine robustness testing. Specifically, this branch introduces a script that applies a perceptual filter simulating anxiety-induced "tunnel vision", a condition characterized in the PRT research by reduced peripheral brightness and saturation.

By processing images with this filter before they enter the VQASynth data generation pipeline, we can create a new dataset to evaluate the spatial reasoning capabilities of Vision Language Models under adverse, noisy conditions. This serves as a proxy for real-world scenarios in embodied AI where sensors might be degraded, occluded, or malfunctioning.

This minimal, self-contained feature branch provides the initial tool for generating these perturbed images. The core thesis is to test whether the spatial reasoning abilities fine-tuned by VQASynth are robust to significant, non-uniform changes in the visual input, providing a new dimension for model evaluation focused on resilience.


### Test Strategy
- Build the base Docker image for the VQASynth environment.
- Execute the script on a sample image: `python experiments/robustness_test/run_anxiety_filter.py assets/warehouse_sample_1.jpeg outputs/perturbed_sample.jpeg`.
- Visually inspect `outputs/perturbed_sample.jpeg` to confirm that the periphery is darkened and desaturated, creating a tunnel vision effect.
- Generate a perturbed dataset by running the script over a subset of images intended for VQA data synthesis.
- Process both the original and perturbed image sets through the full VQASynth pipeline.
- Train a VLM using the data from the original images and evaluate its performance on VQA pairs from both the original and perturbed test sets.


### Success Criteria
- The script successfully applies a visually-plausible tunnel vision filter to input images, controlled by the severity parameter.
- The VLM trained on the original dataset shows a measurable degradation in VQA accuracy (e.g., >10% drop) when evaluated on the dataset generated from perturbed images.
- Analysis of the failures on the perturbed dataset reveals specific weaknesses in spatial reasoning when objects are in low-contrast or low-saturation regions.


**Labels:** experiment, data-synthesis, model-evaluation

---
**Source:** https://github.com/linlab/prt
**Evidence:**
- `README.md`
- `perturbations.py`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2508.09852v1
