### PR TITLE
Feat: Add LogitsProcessor to penalize trivial tokens in CoT generation

### DIFF
--- a/experiments/trivial_token_penalty/run.py
+++ b/experiments/trivial_token_penalty/run.py
@@ -1,0 +1,166 @@
+import torch
+from transformers import (
+    AutoProcessor,
+    LlavaForConditionalGeneration,
+    LogitsProcessor,
+    LogitsProcessorList,
+)
+
+# --- 1. Define the Custom LogitsProcessor inspired by PC-Sampler ---
+# The PC-Sampler paper proposes a "Calibrated Confidence Score" to suppress
+# the selection of trivial tokens by incorporating frequency-based adjustments.
+# We adapt this idea to an autoregressive setting by creating a LogitsProcessor
+# that directly penalizes a predefined list of high-frequency, low-information tokens.
+
+
+class TrivialTokenPenalizer(LogitsProcessor):
+    """
+    A LogitsProcessor that penalizes a specific list of trivial token IDs.
+    This encourages the model to generate more substantive, less conversational content,
+    adapting the core idea of PC-Sampler's Calibrated Confidence Score for autoregressive models.
+
+    Args:
+        trivial_token_ids (list[int]): A list of token IDs to be penalized.
+        penalty (float): The penalty to apply. A value > 1.0 reduces the probability, a large penalty effectively suppresses the token.
+    """
+
+    def __init__(self, trivial_token_ids: list[int], penalty: float = 100.0):
+        if not isinstance(trivial_token_ids, list) or not all(
+            isinstance(i, int) for i in trivial_token_ids
+        ):
+            raise ValueError("`trivial_token_ids` has to be a list of integers.")
+        if not penalty > 0:
+            raise ValueError(
+                f"`penalty` has to be a strictly positive float, but is {penalty}"
+            )
+
+        self.trivial_token_ids = trivial_token_ids
+        self.penalty = penalty
+
+    def __call__(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor
+    ) -> torch.FloatTensor:
+        # For each token in our trivial list, apply a penalty by dividing its logit score.
+        # This makes it much less likely to be sampled.
+        scores[:, self.trivial_token_ids] /= self.penalty
+        return scores
+
+
+# --- 2. Setup Model and Processor ---
+def setup_model_and_processor(model_id="llava-hf/llava-1.5-7b-hf"):
+    """Loads the VLM and its associated processor."""
+    print(f"Loading model: {model_id}...")
+    model = LlavaForConditionalGeneration.from_pretrained(
+        model_id,
+        torch_dtype=torch.float16,
+        low_cpu_mem_usage=True,
+    ).to("cuda:0")
+    processor = AutoProcessor.from_pretrained(model_id)
+    print("Model loaded successfully.")
+    return model, processor
+
+
+def get_trivial_token_ids(processor):
+    """
+    Identifies token IDs for common, low-information words and punctuation.
+    This is a heuristic list, analogous to the reference corpus in PC-Sampler.
+    """
+    trivial_tokens = [
+        ".",
+        ",",
+        "!",
+        "?",
+        ";",
+        ":",
+        "-",
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "so",
+        "well",
+        "actually",
+        "basically",
+        "like",
+        "just",
+        "So",
+        "Well",
+        "Actually",
+        "Basically",
+        "Like",
+        "Just",
+    ]
+    # Convert tokens to IDs, ignoring those not in the tokenizer's vocabulary
+    token_ids = processor.tokenizer.convert_tokens_to_ids(trivial_tokens)
+    return [
+        tid
+        for tid in token_ids
+        if tid is not None and tid != processor.tokenizer.unk_token_id
+    ]
+
+
+# --- 3. Run Generation Experiment ---
+def run_generation(model, processor, prompt, image=None, logits_processor=None):
+    """Runs a single generation pass with or without a logits processor."""
+    inputs = processor(text=prompt, images=image, return_tensors="pt").to(
+        "cuda:0", torch.float16
+    )
+
+    processor_list = (
+        LogitsProcessorList([logits_processor]) if logits_processor else None
+    )
+
+    generate_ids = model.generate(
+        **inputs,
+        max_new_tokens=100,
+        logits_processor=processor_list,
+        do_sample=False,  # Use greedy decoding for reproducibility
+    )
+    return processor.batch_decode(
+        generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
+    )[0]
+
+
+if __name__ == "__main__":
+    # Note: This script does not require an image for this demonstration,
+    # as we are focused on the text generation characteristics.
+    # The prompt simulates the input to the CoT reasoning stage.
+    model_id = (
+        "llava-hf/llava-1.5-7b-hf"  # A standard VLM used in VQASynth-like pipelines
+    )
+    model, processor = setup_model_and_processor(model_id)
+
+    # This prompt is designed to elicit a Chain-of-Thought response.
+    prompt = "USER: <image>\nBased on the image, describe the spatial relationship between the red forklift and the cardboard boxes. Think step-by-step. ASSISTANT:"
+
+    print("\n" + "=" * 50)
+    print("Running BASELINE generation (without penalty)...")
+    print("=" * 50)
+    baseline_output = run_generation(model, processor, prompt)
+    print(baseline_output)
+
+    print("\n" + "=" * 50)
+    print("Running generation with TRIVIAL TOKEN PENALTY...")
+    print("=" * 50)
+    # Instantiate our custom logits processor
+    trivial_ids = get_trivial_token_ids(processor)
+    print(f"Penalizing {len(trivial_ids)} trivial token IDs.")
+    penalizer = TrivialTokenPenalizer(trivial_token_ids=trivial_ids, penalty=100.0)
+
+    penalized_output = run_generation(
+        model, processor, prompt, logits_processor=penalizer
+    )
+    print(penalized_output)
+
+    print("\n" + "=" * 50)
+    print("COMPARISON")
+    print("=" * 50)
+    print(f"Baseline Output:\n{baseline_output.split('ASSISTANT:')[1].strip()}")
+    print("-" * 20)
+    print(f"Penalized Output:\n{penalized_output.split('ASSISTANT:')[1].strip()}")
+    print(
+        "\nExperiment complete. Observe if the penalized output is more concise and less conversational."
+    )


### PR DESCRIPTION
This experiment integrates an idea from the PC-Sampler paper to improve the quality of generated Chain-of-Thought (CoT) reasoning within the VQASynth pipeline. VQASynth generates datasets for spatial reasoning, often involving a CoT step to explain the model's logic. The quality of this reasoning can be diluted by verbose, conversational, or low-information filler tokens.

The SOURCE repository, PC-Sampler, introduces a 'Calibrated Confidence Score' for Masked Diffusion Models. This mechanism suppresses the premature selection of trivial tokens (e.g., punctuation, filler words) by using a frequency-based adjustment, thereby promoting the generation of semantically rich content. This is particularly effective for tasks requiring logical structure, like math and code generation.

We adapt this concept from a non-autoregressive to an autoregressive context by implementing a custom `LogitsProcessor` for Hugging Face transformers. This processor directly penalizes a predefined list of trivial token IDs during inference. By incorporating this processor into the CoT generation step, we hypothesize that the VLM will produce more concise, direct, and informative reasoning chains, improving the overall quality of the synthesized VQA data.


### Test Strategy
- Ensure the required dependencies, including `torch`, `transformers`, and `bitsandbytes`, are installed in the Docker environment.
- Execute the experiment script using a GPU-enabled Docker container: `python experiments/trivial_token_penalty/run.py`.
- The script will download the `llava-1.5-7b-hf` model and run two generation passes: one baseline and one with the `TrivialTokenPenalizer`.
- Observe the console output, which will print the baseline and penalized CoT generations for direct comparison.


### Success Criteria
- The generation process with the `TrivialTokenPenalizer` completes successfully.
- Qualitative analysis of the output shows that the penalized generation is more direct and contains fewer conversational fillers or standalone punctuation compared to the baseline.
- The token count of the penalized CoT response is measurably lower than the baseline response while preserving the core logical steps and conclusions.


**Labels:** data-synthesis, inference-optimization, experiment

---
**Source:** https://github.com/NEUIR/PC-Sampler
**Evidence:**
- `README.md`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2508.13021v1
