### PR TITLE
Feat: Introduce multi-view embeddings for spatial reasoning

### DIFF
--- a/docker/embeddings_stage/process_embeddings.py
+++ b/docker/embeddings_stage/process_embeddings.py
@@ -1,56 +1,134 @@
-import os
-import pickle
 import argparse
-import pandas as pd
+import json
+import os
+from pathlib import Path
+import torch
 from PIL import Image
-from vqasynth.datasets import Dataloader
-from vqasynth.embeddings import EmbeddingGenerator
-from vqasynth.utils import filter_null
+from transformers import CLIPProcessor, CLIPModel
+import numpy as np
 
-def main(output_dir, source_repo_id, images):
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
 
-    dataloader = Dataloader(output_dir)
-    embedding_generator = EmbeddingGenerator()
+def generate_semantic_embedding(model, processor, image_path, device):
+    """Generates a semantic embedding for a given image."""
+    try:
+        image = Image.open(image_path).convert("RGB")
+        inputs = processor(images=image, return_tensors="pt").to(device)
+        with torch.no_grad():
+            image_features = model.get_image_features(**inputs)
+        return image_features.squeeze(0).cpu()
+    except Exception as e:
+        print(f"Warning: Could not process image {image_path}. Error: {e}")
+        return None
 
-    # Load dataset
-    dataset = dataloader.load_dataset(source_repo_id)
 
-    # Apply the embedding generation transformation with batching
-    dataset = dataset.map(
-        embedding_generator.apply_transform,
-        fn_kwargs={'images': images},
-        batched=True,
-        batch_size=32
-    )
+def create_positional_embedding(bbox, img_width, img_height):
+    """
+    Creates a normalized positional embedding from a bounding box.
+    The embedding is [x_min, y_min, x_max, y_max], all normalized to [0, 1].
+    """
+    x1, y1, x2, y2 = bbox
+    normalized_bbox = [x1 / img_width, y1 / img_height, x2 / img_width, y2 / img_height]
+    return torch.tensor(normalized_bbox, dtype=torch.float32)
 
-    # Filter out nulls using the updated function
-    dataset = dataset.filter(filter_null, batched=True, batch_size=32)
 
-    # Save the processed dataset to disk
-    dataloader.save_to_disk(dataset)
-    print("Embedding extraction complete.")
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser("Embedding extraction", add_help=True)
-    parser.add_argument(
-        "--output_dir",
-        type=str,
-        required=True,
-        help="Path to local dataset cache",
-    )
-    parser.add_argument(
-        "--source_repo_id",
-        type=str,
-        required=True,
-        help="Source huggingface dataset repo id",
+def main():
+    """
+    Processes object detections to generate multi-view embeddings.
+    Inspired by the multi-view featurization strategy from the DataCentricBrainGraphs paper,
+    this script combines semantic embeddings (from CLIP) with structural embeddings
+    (normalized bounding box coordinates) to create a richer object representation.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate multi-view object embeddings."
     )
     parser.add_argument(
-        "--images",
+        "--input_path",
         type=str,
         required=True,
-        help="Column containing PIL.Image images",
+        help="Path to the input JSONL file with object detections.",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Path to save the output JSONL file with embeddings.",
+    )
+    parser.add_argument(
+        "--image_dir",
+        type=str,
+        required=True,
+        help="Directory containing the source images.",
     )
     args = parser.parse_args()
-    main(args.output_dir, args.source_repo_id, args.images)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+
+    # Load a pre-trained model for semantic embeddings
+    model_id = "openai/clip-vit-base-patch32"
+    model = CLIPModel.from_pretrained(model_id).to(device)
+    processor = CLIPProcessor.from_pretrained(model_id)
+
+    Path(args.output_path).parent.mkdir(parents=True, exist_ok=True)
+
+    with open(args.input_path, "r") as infile, open(args.output_path, "w") as outfile:
+        for line in infile:
+            data = json.loads(line)
+            image_path = os.path.join(args.image_dir, data["image_filename"])
+
+            if not os.path.exists(image_path):
+                print(f"Warning: Image file not found: {image_path}. Skipping.")
+                continue
+
+            try:
+                with Image.open(image_path) as img:
+                    img_width, img_height = img.size
+            except Exception as e:
+                print(
+                    f"Warning: Could not open image {image_path}. Error: {e}. Skipping."
+                )
+                continue
+
+            # For this experiment, we generate embeddings for cropped objects.
+            base_image = Image.open(image_path).convert("RGB")
+
+            processed_objects = []
+            for obj in data.get("objects", []):
+                bbox = obj.get("bounding_box")  # Expected format: [x1, y1, x2, y2]
+                if not bbox or len(bbox) != 4:
+                    print(
+                        f"Warning: Skipping object with invalid bounding box in {data['image_filename']}"
+                    )
+                    continue
+
+                # View 1: Semantic Embedding from the cropped object
+                cropped_image = base_image.crop(bbox)
+                inputs = processor(images=cropped_image, return_tensors="pt").to(device)
+                with torch.no_grad():
+                    semantic_embedding = (
+                        model.get_image_features(**inputs).squeeze(0).cpu()
+                    )
+
+                # View 2: Structural/Positional Embedding
+                positional_embedding = create_positional_embedding(
+                    bbox, img_width, img_height
+                )
+
+                # Concatenate the two views to create the multi-view embedding
+                multi_view_embedding = torch.cat(
+                    (semantic_embedding, positional_embedding), dim=0
+                )
+
+                obj["multi_view_embedding"] = multi_view_embedding.tolist()
+                obj["semantic_embedding_dim"] = len(semantic_embedding)
+                obj["positional_embedding_dim"] = len(positional_embedding)
+                processed_objects.append(obj)
+
+            data["objects"] = processed_objects
+            outfile.write(json.dumps(data) + "\n")
+
+    print(f"Processing complete. Output saved to {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Inspired by the 'Data-Centric AI' approach in the SOURCE repository (DataCentricBrainGraphs), this experiment proposes a change to the data synthesis pipeline to improve object representation. The SOURCE paper demonstrates that creating multi-view features, such as concatenating different correlation metrics and lagged dynamics for brain graphs, significantly improves downstream model performance. We adapt this principle to VQASynth's goal of enhancing spatial reasoning in VLMs.

This feature branch modifies the embedding generation stage to create a richer, 'multi-view' feature vector for each detected object. Instead of relying solely on a semantic embedding (e.g., from CLIP), we concatenate it with a structural, positional embedding derived from the object's normalized bounding box coordinates. This explicitly encodes 'where' an object is in the image alongside 'what' it is.

The hypothesis is that providing the model with this fused representation from the outset will improve its ability to learn and reason about spatial relationships, distances, and orientations. This experiment treats the featurization step of the data synthesis pipeline as a critical design choice, directly reflecting the systematic, data-centric evaluation methodology advocated for in the SOURCE material.


### Test Strategy
- Create a sample input JSONL file with at least two image records, each containing a list of objects with 'bounding_box' keys.
- Place the corresponding images in a test directory.
- Run the `process_embeddings.py` script, providing paths to the sample input, image directory, and a target output file.
- Inspect the output JSONL file. Verify that each object now has a 'multi_view_embedding' key.
- Confirm that the length of the 'multi_view_embedding' list is equal to the sum of 'semantic_embedding_dim' (512 for CLIP ViT-B/32) and 'positional_embedding_dim' (4).


### Success Criteria
- The script runs without errors and produces an output file where object dictionaries are correctly augmented with concatenated multi-view embeddings.
- A VLM fine-tuned on a dataset generated with these multi-view embeddings demonstrates a statistically significant improvement on a spatial reasoning benchmark (e.g., accuracy on relative positioning questions) compared to a baseline model trained with only semantic embeddings.


**Labels:** experiment, data-synthesis, featurization

---
**Source:** https://github.com/GeQinwen/DataCentricBrainGraphs
**Evidence:**
- `README.md`
- `src/featurization/lag_correlation.py`

**Experiment metadata:**
- experiment_id: local-1756063456
- run_id: run-1
- paper_id: 2508.12533v1
