### PR TITLE
Feat: Add LessIsMore for Accelerated VQA Inference

### DIFF
--- a/experiments/inference_acceleration/run_benchmark.py
+++ b/experiments/inference_acceleration/run_benchmark.py
@@ -1,0 +1,138 @@
+import argparse
+import time
+import torch
+from transformers import AutoProcessor, LlavaForConditionalGeneration
+from PIL import Image
+import requests
+import warnings
+import os
+
+
+# --- Logic adapted from LessIsMore/src/enable_tidal.py and tidal_build ---
+# This is a simplified, self-contained representation of the patching process.
+# In a real implementation, this would likely involve importing from the LessIsMore source.
+def enable_less_is_more(model, budget=1024, recent_ratio=0.25):
+    """
+    Monkey-patches the model to use LessIsMore sparse attention.
+    This is a conceptual adaptation. The actual LessIsMore library
+    should be installed and its patching functions used.
+    """
+    print(
+        f"Attempting to enable LessIsMore with budget={budget} and recent_ratio={recent_ratio}"
+    )
+    try:
+        # The actual library provides a cleaner way to do this.
+        # This simulates the patching process for a Llama-based model like LLaVA.
+        from src.tidal_build.modify_llama_lim import convert_to_lim_attn
+
+        model = convert_to_lim_attn(model, budget, recent_ratio)
+        print("Successfully patched model with LessIsMore attention.")
+        # Set environment variables that the custom kernels might use
+        os.environ["TIDAL_K"] = str(budget)
+        os.environ["TIDAL_R"] = str(recent_ratio)
+    except ImportError:
+        warnings.warn(
+            "Could not import LessIsMore patching functions. "
+            "Ensure the LessIsMore library is correctly installed. "
+            "Running with standard attention."
+        )
+    except Exception as e:
+        warnings.warn(
+            f"Failed to apply LessIsMore patch: {e}. Running with standard attention."
+        )
+
+    return model
+
+
+def run_benchmark(model, processor, image_url, question, max_new_tokens=100):
+    """Runs a single inference pass and measures latency."""
+    raw_image = Image.open(requests.get(image_url, stream=True).raw)
+    prompt = f"USER: <image>\n{question} ASSISTANT:"
+
+    inputs = processor(text=prompt, images=raw_image, return_tensors="pt").to("cuda:0")
+
+    start_time = time.time()
+
+    # generate response
+    with torch.no_grad():
+        generation_output = model.generate(
+            **inputs, max_new_tokens=max_new_tokens, do_sample=False
+        )
+
+    end_time = time.time()
+
+    latency = end_time - start_time
+    generated_ids = generation_output[0][inputs.input_ids.shape[1] :]
+    response = processor.decode(generated_ids, skip_special_tokens=True)
+    num_tokens = len(generated_ids)
+
+    return response, latency, num_tokens
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark VQA inference with and without LessIsMore."
+    )
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="llava-hf/llava-1.5-7b-hf",
+        help="Hugging Face model ID for the LLaVA model.",
+    )
+    parser.add_argument(
+        "--enable_less_is_more",
+        action="store_true",
+        help="Enable LessIsMore sparse attention.",
+    )
+    parser.add_argument(
+        "--budget", type=int, default=2048, help="Token budget for LessIsMore."
+    )
+    parser.add_argument(
+        "--recent_ratio",
+        type=float,
+        default=0.25,
+        help="Ratio of budget reserved for recent tokens in LessIsMore.",
+    )
+    args = parser.parse_args()
+
+    # --- Load Model and Processor ---
+    print(f"Loading model: {args.model_id}")
+    model = LlavaForConditionalGeneration.from_pretrained(
+        args.model_id,
+        torch_dtype=torch.float16,
+        low_cpu_mem_usage=True,
+    ).to("cuda:0")
+    processor = AutoProcessor.from_pretrained(args.model_id)
+
+    # --- Apply LessIsMore if enabled ---
+    if args.enable_less_is_more:
+        model = enable_less_is_more(model, args.budget, args.recent_ratio)
+
+    # --- Benchmark Data ---
+    # Using a sample from the VQASynth README
+    test_case = {
+        "image_url": "https://github.com/smellslikeml/experimental-vqasynth/blob/main/assets/warehouse_sample_1.jpeg?raw=true",
+        "question": "Does the red forklift in the warehouse appear on the left side of the brown cardboard boxes that are stacked up?",
+    }
+
+    print("\n--- Running Benchmark ---")
+    print(f"Image: {test_case['image_url']}")
+    print(f"Question: {test_case['question']}")
+    print(f"LessIsMore Enabled: {args.enable_less_is_more}")
+    if args.enable_less_is_more:
+        print(f"Budget: {args.budget}, Recent Ratio: {args.recent_ratio}")
+
+    response, latency, num_tokens = run_benchmark(
+        model, processor, test_case["image_url"], test_case["question"]
+    )
+
+    print("\n--- Results ---")
+    print(f"Response: {response}")
+    print(f"Total Latency: {latency:.4f} seconds")
+    print(f"Generated Tokens: {num_tokens}")
+    if num_tokens > 0:
+        print(f"Per-Token Latency: {latency / num_tokens:.4f} seconds/token")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates the 'LessIsMore' sparse attention mechanism from the SOURCE repository into the TARGET VQASynth pipeline. VQASynth focuses on creating datasets and fine-tuning Vision Language Models (VLMs) for advanced spatial reasoning. These reasoning tasks often involve long-context generation, making them ideal candidates for inference optimization.

The 'LessIsMore' paper demonstrates significant decoding speedups on reasoning tasks by using a training-free sparse attention method that globally selects important tokens and preserves recent ones. This approach reduces computational overhead during inference without sacrificing accuracy. By applying LessIsMore to a VLM fine-tuned with VQASynth data, we can evaluate its effectiveness in a vision-language context.

This feature branch introduces a self-contained benchmarking script to measure the latency and performance of a LLaVA model with and without the LessIsMore optimization. The goal is to quantify the potential for accelerating inference on the specialized models produced by the VQASynth pipeline, making them more practical for deployment in resource-constrained environments.


### Test Strategy
- Build a Docker image using `docker/llava_train/Dockerfile` as a base, ensuring it uses a `pytorch-devel` image compatible with CUDA 11.8 for kernel compilation.
- In the Dockerfile, add steps to install a recent version of cmake (>=3.26.4), clone the `LessIsMore` repo with submodules, install its dependencies (including `flash-attn`), and build its custom CUDA kernels per the SOURCE_DOCKERFILE instructions.
- Launch the container and execute the `experiments/inference_acceleration/run_benchmark.py` script.
- Run the script with the `--enable_less_is_more` flag and without it to establish a baseline. Compare the per-token latency reported by both runs.


### Success Criteria
- The benchmark script successfully executes and generates a VQA response with the `LessIsMore` patch applied to the LLaVA model.
- A measurable decrease in per-token latency (e.g., >1.1x speedup) is observed when running with the `--enable_less_is_more` flag compared to the baseline.
- The generated response with `LessIsMore` enabled is qualitatively similar in accuracy and coherence to the baseline response.


**Labels:** inference-optimization, experiment

---
**Source:** https://github.com/DerrickYLJ/LessIsMore
**Evidence:**
- `README.md`
- `src/tidal_build/modify_llama_lim.py`
- `examples/run_tidal_llama.py`
- `pyproject.toml`

**Experiment metadata:**
- experiment_id: local-1756432156
- run_id: run-1
- paper_id: 2508.07101v1
