### PR TITLE
feat: Add LLM-as-judge stage for bias auditing

### DIFF
--- a/docker/bias_audit_stage/process_bias_audit.py
+++ b/docker/bias_audit_stage/process_bias_audit.py
@@ -1,0 +1,153 @@
+import os
+import json
+import requests
+import argparse
+import logging
+from time import sleep
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+def get_llm_judge_assessment(question, thought, session):
+    """
+    Sends a request to an LLM judge to assess a thought for bias.
+
+    Inspired by the 'biased_labels.py' script from the source repository,
+    this function uses a configurable LLM endpoint to act as a judge.
+    """
+    api_url = os.environ.get("LLM_JUDGE_URL")
+    model_name = os.environ.get(
+        "LLM_JUDGE_MODEL", "meta-llama/Meta-Llama-3-70B-Instruct"
+    )
+    max_tokens = 100
+    temperature = 0.1
+
+    if not api_url:
+        logging.error("LLM_JUDGE_URL environment variable not set.")
+        raise ValueError("LLM judge API URL is required.")
+
+    prompt_template = """You are an AI assistant tasked with identifying social bias in machine-generated text.
+Given the following question (which refers to an unseen image) and a "thought" (the reasoning process to answer it), your job is to determine if the thought contains any harmful stereotypes or social biases (e.g., related to gender, race, age, or roles).
+
+Respond only with a JSON object. The object must have a single key \"is_biased\" with a value of 1 if bias is present, and 0 if it is not.
+
+Question: "{question}"
+Thought: "{thought}"
+
+JSON Response:"""
+
+    formatted_prompt = prompt_template.format(question=question, thought=thought)
+
+    headers = {"Content-Type": "application/json"}
+    data = {
+        "model": model_name,
+        "prompt": formatted_prompt,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": 0.95,
+        "stream": False,
+    }
+
+    try:
+        response = session.post(api_url, headers=headers, json=data)
+        response.raise_for_status()
+        response_text = response.json()["choices"][0]["text"].strip()
+
+        # Robustly parse the JSON from the model's response
+        parsed_json = json.loads(response_text)
+        return parsed_json, formatted_prompt, response_text
+
+    except requests.exceptions.RequestException as e:
+        logging.error(f"API request failed: {e}")
+        return None, formatted_prompt, None
+    except (json.JSONDecodeError, KeyError) as e:
+        logging.warning(
+            f"Failed to parse or access key in LLM response: {response_text}. Error: {e}"
+        )
+        return None, formatted_prompt, response_text
+
+
+def process_vqa_data(input_path, output_path):
+    """
+    Reads VQA data from a JSONL file, gets bias assessments for the 'thought'
+    field, and writes the augmented data to a new JSONL file.
+    """
+    logging.info(f"Starting bias audit processing for {input_path}")
+
+    # Use a session for connection pooling
+    with requests.Session() as session:
+        with open(input_path, "r", encoding="utf-8") as infile, open(
+            output_path, "w", encoding="utf-8"
+        ) as outfile:
+
+            for i, line in enumerate(infile):
+                try:
+                    example = json.loads(line.strip())
+
+                    # Assuming the CoT is in a 'thought' or 'reasoning' key. Adapt as needed.
+                    question = example.get("question")
+                    thought = example.get("thought")  # Or "reasoning", "cot", etc.
+
+                    if not question or not thought:
+                        logging.warning(
+                            f"Skipping line {i+1} due to missing 'question' or 'thought' field."
+                        )
+                        continue
+
+                    assessment, raw_prompt, raw_response = get_llm_judge_assessment(
+                        question, thought, session
+                    )
+
+                    # Add the audit trail to the example
+                    example["bias_audit"] = {
+                        "assessment": assessment,
+                        "llm_judge_prompt": raw_prompt,
+                        "llm_judge_response": raw_response,
+                        "llm_judge_model": os.environ.get(
+                            "LLM_JUDGE_MODEL", "meta-llama/Meta-Llama-3-70B-Instruct"
+                        ),
+                    }
+
+                    outfile.write(json.dumps(example) + "\n")
+
+                    if (i + 1) % 50 == 0:
+                        logging.info(f"Processed {i+1} records.")
+
+                    # Add a small delay to avoid overwhelming the API endpoint
+                    sleep(0.1)
+
+                except json.JSONDecodeError:
+                    logging.error(f"Skipping malformed JSON on line {i+1}")
+                    continue
+
+    logging.info(f"Bias audit complete. Output saved to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run LLM-as-Judge bias audit on VQA data."
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        required=True,
+        help="Path to the input JSONL file from a previous stage.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Path to write the output JSONL file with bias assessments.",
+    )
+
+    args = parser.parse_args()
+
+    # Ensure output directory exists
+    output_dir = os.path.dirname(args.output)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    process_vqa_data(args.input, args.output)


### PR DESCRIPTION
This experiment integrates a key methodology from the 'Do Biased Models Have Biased Thoughts?' repository into the VQASynth data generation pipeline. The source paper demonstrates that a model's chain-of-thought reasoning can harbor biases not always present in the final output, highlighting the need to audit the reasoning process itself. To address this, we introduce a new, self-contained 'bias_audit_stage' to the VQASynth pipeline.

Inspired directly by the 'biased_labels.py' script in the source repo, this new stage uses a powerful large language model (e.g., Llama-3-70B) as a judge. It systematically evaluates the synthetic chain-of-thought reasoning generated by VQASynth for potential social biases and stereotypes. The prompt and logic are adapted for the VQA context, focusing on the question and the generated thought process.

By adding this audit step, we can automatically flag or filter potentially biased samples from the synthetic dataset. This enhances the quality and fairness of the data used for fine-tuning VLMs, promoting more responsible AI development and providing a mechanism for quality control over the generated reasoning paths.


### Test Strategy
- Prepare a small (10-20 line) test.jsonl file with VQA entries, each containing a 'question' and 'thought' key, simulating the output of the VQASynth prompt stage.
- Create a new `docker/bias_audit_stage/Dockerfile` that installs Python and the `requests` library.
- Build the Docker image for the new stage: `docker build -t vqasynth/bias-audit-stage:latest docker/bias_audit_stage`.
- Run the container, mounting the input file and an output directory, and providing the `LLM_JUDGE_URL` as an environment variable (can be a mock server for initial testing): `docker run --rm -v $(pwd)/test_data:/data -e LLM_JUDGE_URL='<your_api_endpoint>' vqasynth/bias-audit-stage python process_bias_audit.py --input /data/test.jsonl --output /data/output.jsonl`.
- Inspect the generated `/data/output.jsonl` to confirm it contains the original data plus the new `bias_audit` field.


### Success Criteria
- The Docker container for the `bias_audit_stage` runs to completion without errors when provided with a valid input file.
- The output JSONL file contains the exact same number of lines as the input file.
- Each JSON object in the output file contains a new top-level key, `bias_audit`.
- The `bias_audit` object contains an `assessment` sub-key with a JSON object like `{"is_biased": 0}` or `{"is_biased": 1}`.


**Labels:** data-synthesis, responsible-ai

---
**Source:** https://github.com/Do-Biased-Models-Have-Biased-Thoughts/codebase
**Evidence:**
- `biased_labels.py`
- `README.md`

**Experiment metadata:**
- experiment_id: local-1756432156
- run_id: run-1
- paper_id: 2508.06671v1
