### PR TITLE
Integrate TechOps Documentation Framework

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.4
+# This Dockerfile sets up an environment to build and serve the project documentation.
+# It is based on the TechOps documentation rendering blueprint.
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy and install the documentation-specific dependencies
+COPY requirements.docs.txt .
+RUN pip install --no-cache-dir -r requirements.docs.txt
+
+# Copy the documentation source files and config
+COPY docs/ ./docs/
+COPY mkdocs.yml .
+
+# Expose the default port for mkdocs
+EXPOSE 8000
+
+# Run the mkdocs development server, accessible from outside the container
+CMD ["mkdocs", "serve", "--dev-addr", "0.0.0.0:8000"]

--- a/docs/application-documentation.md
+++ b/docs/application-documentation.md
@@ -1,0 +1,23 @@
+# VQASynth Application Documentation
+
+## 1. System Overview
+
+**VQASynth** is a data synthesis pipeline designed to enhance the spatial reasoning capabilities of Vision Language Models (VLMs). It addresses the scarcity of spatial reasoning data in common pretraining datasets by generating high-quality, synthetic Visual Question Answering (VQA) samples from any image dataset on the Huggingface Hub.
+
+The system fuses semantic and metric data into templated VQA conversations. It integrates several models for 3D scene reconstruction and understanding, including:
+
+- Metric depth estimation with VGGT
+- Object localization and refinement with SAM2
+- Object-grounded captioning
+
+### 1.1 Intended Use
+
+The primary intended use of VQASynth is to generate instruction-tuning datasets for VLMs. Models fine-tuned on this data are expected to improve their ability to:
+
+*   Estimate 3D distances between objects in a 2D image.
+*   Describe spatial relationships and orientations colloquially (e.g., "left of," "behind").
+*   Convert between common units of measurement.
+*   Base responses on consistent references like floors and surfaces.
+*   Apply Chain-of-Thought (CoT) "thinking" for more robust reasoning.
+
+This enhanced capability is crucial for embodied AI applications such as robotics, augmented reality, and autonomous navigation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Welcome to VQASynth Documentation
+
+This site provides technical documentation for the VQASynth project, an experimental framework for generating synthetic VQA data to enhance the spatial reasoning capabilities of Vision Language Models (VLMs).
+
+This documentation is built using the [TechOps](https://github.com/aloosley/techops) framework, designed to provide comprehensive and accessible information for developers, researchers, and users.
+
+## Navigation
+
+Use the sidebar to navigate through the documentation sections:
+
+*   **Application Documentation:** Learn about the VQASynth system as a whole, its intended use, architecture, and performance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: VQASynth Documentation
+nav:
+- Home: index.md
+- Application Documentation: application-documentation.md
+theme:
+  name: rtd-dropdown
+markdown_extensions:
+- toc:
+    permalink: true
+plugins:
+  - search

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.1.2
+mkdocs-rtd-dropdown>=1.0.0


### PR DESCRIPTION
VQASynth is a complex, multi-stage AI system for data synthesis that currently lacks a centralized, structured documentation hub. This makes it difficult for new contributors to understand the architecture and for stakeholders to assess its components and intended use. The SOURCE repo, TechOps, provides a blueprint for creating comprehensive technical documentation for AI/ML systems, with a focus on transparency, compliance, and accessibility for diverse audiences.

This feature branch integrates the core ideas from TechOps into VQASynth by introducing a documentation site built with `mkdocs`. It adds the necessary configuration, initial content templates populated with information from the existing README, and a self-contained Docker environment for building and serving the docs. This new documentation system is isolated from the main application's environment to ensure no dependency conflicts arise.

By adopting this structured approach, we establish a foundation for thorough documentation that can evolve with the project. This experiment aims to improve project maintainability, onboarding for new developers, and alignment with responsible AI development practices by making the system's design and function more transparent.


### Test Strategy
- Build the documentation Docker image from the root of the repository: `docker build -t vqasynth-docs -f docker/Dockerfile.docs .`
- Run the container, mapping the port to the host: `docker run --rm -p 8000:8000 vqasynth-docs`
- Open a web browser and navigate to `http://localhost:8000` to view the documentation site.


### Success Criteria
- The Docker container builds and runs without errors.
- The mkdocs server is accessible at `http://localhost:8000`.
- The rendered website displays the title 'VQASynth Documentation'.
- The site includes a 'Home' page and an 'Application Documentation' page, with content correctly rendered from the new markdown files.
- The visual theme matches the `rtd-dropdown` theme specified in `mkdocs.yml`.


**Labels:** experiment, documentation, responsible-ai

---
**Source:** https://github.com/aloosley/techops
**Evidence:**
- `README.md`
- `mkdocs.yaml`
- `pyproject.toml`

**Experiment metadata:**
- experiment_id: local-1756432156
- run_id: run-1
- paper_id: 2508.08804v1
