### PR TITLE
feat: Integrate structured CSV logger for experiment tracking

### DIFF
--- a/experiments/logging_demo/run.py
+++ b/experiments/logging_demo/run.py
@@ -1,0 +1,58 @@
+import uuid
+from pathlib import Path
+
+# This logger is sourced from the causal-reasoning-in-pieces repository
+# and added to the project's utils.
+from experiments.utils.experiment_logger import ExperimentLogger
+
+
+def generate_fake_vqa_data(num_samples: int):
+    """Generates a list of fake VQA data records for demonstration."""
+    records = []
+    for i in range(num_samples):
+        record = {
+            "image_id": f"img_{i:04d}.jpg",
+            "question": f"Is object A to the left of object B in image {i}?",
+            "answer": "Yes" if i % 2 == 0 else "No",
+            "reasoning_chain": "1. Identified Object A. 2. Identified Object B. 3. Determined relative position. 4. Formulated answer.",
+            "confidence": 0.95 - (i * 0.01),
+            "generation_model": "gpt-4-vision-preview",
+        }
+        records.append(record)
+    return records
+
+
+def main():
+    """
+    Demonstrates the use of the ExperimentLogger for tracking VQA data generation.
+    """
+    print("Starting VQA data generation logging demo...")
+
+    # Define output directory for logs
+    output_dir = Path("output/logging_demo")
+
+    # Initialize the logger with a unique job ID
+    job_id = f"vqa-gen-{uuid.uuid4().hex[:8]}"
+    logger = ExperimentLogger(logs_dir=output_dir, job_id=job_id)
+
+    print(f"Logger initialized. Log file will be saved in: {logger.log_file.parent}")
+
+    # Generate and log a single record using append()
+    print("Logging a single record...")
+    single_record = generate_fake_vqa_data(1)[0]
+    single_record["notes"] = (
+        "Logged individually"  # Logger dynamically handles new columns
+    )
+    logger.append(single_record)
+
+    # Generate and log a batch of records using append_many()
+    print("Logging a batch of records...")
+    batch_records = generate_fake_vqa_data(5)
+    logger.append_many(batch_records)
+
+    print("Demo finished successfully.")
+    print(f"Please check the CSV log file: {logger.log_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/utils/experiment_logger.py
+++ b/experiments/utils/experiment_logger.py
@@ -1,0 +1,54 @@
+import csv
+import datetime
+from pathlib import Path
+from typing import Optional, Any
+
+
+class ExperimentLogger:
+    """
+    Create logging CSV file up‑front and append rows to it as each experiment finishes.
+    """
+
+    def __init__(self, logs_dir: Path, job_id: Optional[str] = None) -> None:
+        self.logs_dir = logs_dir
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+
+        job_suffix = f"_{job_id}" if job_id else ""
+        filename = f"experiment_results_{timestamp}{job_suffix}.csv"
+        self.log_file = self.logs_dir / filename
+
+        self._fieldnames: Optional[list[str]] = None
+
+    def _init_header(self, fieldnames: list[str]) -> None:
+        with self.log_file.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+        self._fieldnames = fieldnames
+
+    def _coerce(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy with hypothesis_label formatted to int."""
+        if "hypothesis_label" in record:
+            record = {**record, "hypothesis_label": int(record["hypothesis_label"])}
+        return record
+
+    def append(self, record: dict[str, Any]) -> None:
+        if self._fieldnames is None:
+            self._init_header(list(record.keys()))
+
+        with self.log_file.open("a", newline="") as f:
+            csv.DictWriter(f, fieldnames=self._fieldnames).writerow(
+                self._coerce(record)
+            )
+
+    def append_many(self, records: list[dict[str, Any]]) -> None:
+        if not records:
+            return
+
+        if self._fieldnames is None:
+            self._init_header(list(records[0].keys()))
+
+        with self.log_file.open("a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=self._fieldnames)
+            writer.writerows(map(self._coerce, records))


### PR DESCRIPTION
This experiment integrates the `ExperimentLogger` from the `causal-reasoning-in-pieces` (SOURCE) repository into VQASynth (TARGET). The SOURCE repo demonstrates a highly modular architecture for complex reasoning tasks, and its components, like the logger, are well-designed for reusability and robust experiment tracking. The logger creates a timestamped and job-ID-labeled CSV file, automatically handles headers, and provides methods for appending single or multiple records, which is a significant improvement over ad-hoc print statements or manual file handling.

By incorporating this utility into the VQASynth pipeline, we can introduce a more structured and standardized way to log the outputs of the data generation stages. This is particularly useful for tracking the large volume of VQA pairs, metadata, and reasoning chains produced. A standardized CSV output facilitates easier analysis, debugging, and comparison between different data generation runs.

This feature branch introduces the logger and a simple demonstration script within a new `experiments/` directory. The demo simulates the generation of VQA data and logs it to a CSV file, showcasing how this component can be adopted within the broader VQASynth data synthesis pipeline to improve reproducibility and data management.


### Test Strategy
- Set up a Python virtual environment and install dependencies from the target repo's `requirements.txt`.
- Run the demonstration script from the root of the repository: `python experiments/logging_demo/run.py`.
- Verify that the `output/logging_demo/` directory is created.
- Inspect the generated CSV file inside the output directory. Its name should match the pattern `experiment_results_YYYYMMDD_HHMMSS_ffffff_vqa-gen-xxxxxxxx.csv`.
- Open the CSV file and confirm that it contains a header row and 6 data rows with the correct content generated by the script.


### Success Criteria
- The script `experiments/logging_demo/run.py` executes without errors.
- A structured CSV log file is created in the `output/logging_demo` directory.
- The CSV file contains headers that match the keys of the dictionaries being logged.
- The rows in the CSV file accurately reflect the data generated in the demonstration script.


**Labels:** experiment, data-synthesis

---
**Source:** https://github.com/kacperkadziolka/causal-reasoning-in-pieces
**Evidence:**
- `causal_discovery/experiment_logger.py`

**Experiment metadata:**
- experiment_id: local-1756688486
- run_id: run-1
- paper_id: 2507.23488v1
