### PR TITLE
Experiment: Deploy CODA Planner/Executor Inference Services

### DIFF
--- a/experiments/coda_agent/run_services.sh
+++ b/experiments/coda_agent/run_services.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script sets up the inference services for the CODA dual-brain agent.
+# It starts two VLLM servers: one for the planner model and one for the executor model.
+# This provides the core components of the CODA agent for testing and integration.
+#
+# Based on the deployment strategy outlined in the CODA repository:
+# https://github.com/OpenIXCLab/CODA
+#
+# Prerequisites:
+# 1. A Python environment with CUDA support.
+# 2. `vllm` and `huggingface-hub` installed:
+#    pip install "vllm>=0.4.0" huggingface-hub
+# 3. Logged into Hugging Face Hub with a token that has read access:
+#    huggingface-cli login
+
+# --- Configuration ---
+PLANNER_MODEL="OpenIXCLab/CODA-PLANNER-TARS-32B"
+EXECUTOR_MODEL="ByteDance-Seed/UI-TARS-1.5-7B"
+
+PLANNER_PORT=${PLANNER_PORT:-8000}
+EXECUTOR_PORT=${EXECUTOR_PORT:-8001}
+
+# Using a tensor parallel size of 1 for a minimal, single-GPU setup.
+TENSOR_PARALLEL_SIZE=${TENSOR_PARALLEL_SIZE:-1}
+
+# --- Service Deployment ---
+
+echo "Starting CODA Planner service..."
+echo "  - Model: ${PLANNER_MODEL}"
+echo "  - Port: ${PLANNER_PORT}"
+echo "  - TP Size: ${TENSOR_PARALLEL_SIZE}"
+
+vllm serve "${PLANNER_MODEL}" \
+    --served-model-name "coda-planner" \
+    --host 0.0.0.0 \
+    --port "${PLANNER_PORT}" \
+    --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" & 
+PLANNER_PID=$!
+echo "Planner service starting with PID ${PLANNER_PID}."
+
+echo "-------------------------------------"
+sleep 5
+
+echo "Starting CODA Executor service..."
+echo "  - Model: ${EXECUTOR_MODEL}"
+echo "  - Port: ${EXECUTOR_PORT}"
+echo "  - TP Size: ${TENSOR_PARALLEL_SIZE}"
+
+vllm serve "${EXECUTOR_MODEL}" \
+    --served-model-name "coda-executor" \
+    --host 0.0.0.0 \
+    --port "${EXECUTOR_PORT}" \
+    --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" &
+EXECUTOR_PID=$!
+echo "Executor service starting with PID ${EXECUTOR_PID}."
+
+echo "-------------------------------------"
+
+echo
+echo "Both services are starting in the background."
+echo "Planner URL: http://localhost:${PLANNER_PORT}"
+echo "Executor URL: http://localhost:${EXECUTOR_PORT}"
+echo
+echo "To check service health (wait for models to load), run:"
+echo "  curl http://localhost:${PLANNER_PORT}/health"
+echo "  curl http://localhost:${EXECUTOR_PORT}/health"
+echo
+echo "To stop the services, run:"
+echo "  kill ${PLANNER_PID} ${EXECUTOR_PID}"
+echo
+
+# Wait for any process to exit, then clean up others.
+trap 'kill $(jobs -p)' EXIT
+wait -n


### PR DESCRIPTION
This experiment integrates the core inference architecture of CODA, a dual-brain agent framework for complex computer interaction tasks. The TARGET repo, VQASynth, focuses on generating static VQA data to improve spatial reasoning in VLMs. In contrast, the SOURCE repo, CODA, demonstrates a dynamic, agentic approach where a planner model decomposes tasks for a specialist executor model to perform GUI actions. This approach represents a more advanced form of reasoning and interaction than static VQA.

By isolating and deploying CODA's planner and executor models via VLLM, this branch establishes a foundational component for exploring agent-based data generation. The provided script allows for the easy setup of these core services. This enables future experiments where agent interaction traces within simulated environments could be captured and transformed into rich training data, potentially augmenting VQASynth datasets with examples of sequential decision-making and tool use.

This minimal, self-contained feature provides the necessary infrastructure to begin exploring the fusion of agentic systems with data synthesis pipelines. It brings the powerful planner/executor paradigm from CODA into the VQASynth ecosystem, paving the way for generating more sophisticated spatial and procedural reasoning datasets.


### Test Strategy
- Ensure prerequisites are met: Python with CUDA, `pip install vllm huggingface-hub`.
- Authenticate with Hugging Face Hub using `huggingface-cli login`.
- Make the script executable: `chmod +x experiments/coda_agent/run_services.sh`.
- Execute the script: `./experiments/coda_agent/run_services.sh`.
- Monitor the logs to ensure both models download and load without errors.
- Once the logs indicate the servers are running, check their health status in a separate terminal: `curl http://localhost:8000/health` and `curl http://localhost:8001/health`.


### Success Criteria
- The script executes without errors.
- Two `vllm serve` processes are running in the background for the planner and executor models.
- Both the planner (port 8000) and executor (port 8001) services become responsive.
- Sending a GET request to the `/health` endpoint of each service returns a 200 OK status code.


**Labels:** experiment, data-synthesis, inference-optimization, agentic-systems

---
**Source:** https://github.com/OpenIXCLab/CODA
**Evidence:**
- `README.md`

**Experiment metadata:**
- experiment_id: local-1756688486
- run_id: run-1
- paper_id: 2508.20096v1
