### PR TITLE
Feat: Implement LogicORM Echo Generation for Negative Reasoning Samples

### DIFF
--- a/experiments/logic-orm-echo-generation/run.py
+++ b/experiments/logic-orm-echo-generation/run.py
@@ -1,0 +1,110 @@
+import argparse
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# This script is a minimal implementation of the 'echo generation' technique
+# described in the LogicORM paper (SOURCE repo).
+# The goal is to generate flawed reasoning chains by providing the model
+# with a deliberately incorrect conclusion and prompting it to justify that conclusion.
+# This creates negative training data for training a reward model or for preference tuning.
+
+
+def generate_echo_reasoning(model, tokenizer, premise, incorrect_conclusion, device):
+    """
+    Generates a flawed reasoning chain by 'echoing' an incorrect conclusion.
+
+    Args:
+        model: The pretrained Hugging Face model.
+        tokenizer: The tokenizer for the model.
+        premise (str): The logical premises.
+        incorrect_conclusion (str): The incorrect conclusion to steer the model towards.
+        device (str): The device to run inference on ('cuda', 'cpu', etc.).
+
+    Returns:
+        str: The generated flawed reasoning chain.
+    """
+    # The prompt is designed to coax the model into producing a flawed argument.
+    # It explicitly asks the model to justify a known incorrect outcome, simulating the
+    # 'echo' effect where the LLM reflects the prompt's assumptions.
+    # This is inspired by the data generation process in `src/data_generation.py` of the SOURCE repo.
+    prompt_template = (
+        "You are an expert in logical fallacies. Your task is to construct a plausible-sounding but ultimately incorrect step-by-step argument. "
+        "Start from the given premises and forcibly arrive at the given incorrect conclusion.\n\n"
+        "## Premises: {premise}\n"
+        "## Incorrect Conclusion: {incorrect_conclusion}\n\n"
+        "## Flawed Reasoning Chain:"
+    )
+
+    formatted_prompt = prompt_template.format(
+        premise=premise, incorrect_conclusion=incorrect_conclusion
+    )
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant that follows instructions precisely, even if they lead to logically incorrect outcomes.",
+        },
+        {"role": "user", "content": formatted_prompt},
+    ]
+
+    text = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+
+    model_inputs = tokenizer([text], return_tensors="pt").to(device)
+
+    generated_ids = model.generate(
+        **model_inputs,
+        max_new_tokens=256,
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.9,
+    )
+
+    input_length = model_inputs.input_ids.shape[1]
+    generated_ids = generated_ids[:, input_length:]
+
+    response = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
+    return response
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate flawed reasoning chains using the LogicORM echo technique."
+    )
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="Qwen/Qwen2-0.5B-Instruct",
+        help="The Hugging Face model to use for generation.",
+    )
+    args = parser.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Using device: {device}")
+
+    print(f"Loading model: {args.model_name}")
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_name, torch_dtype="auto", device_map="auto"
+    )
+
+    # Example of a simple deductive reasoning problem.
+    # The correct conclusion is 'Socrates is mortal.'
+    premise = "1. All men are mortal.\n2. Socrates is a man."
+    incorrect_conclusion = "Socrates is not mortal."
+
+    print("-" * 50)
+    print(f"Premise:\n{premise}")
+    print(f"Forcing Incorrect Conclusion:\n{incorrect_conclusion}")
+    print("-" * 50)
+    print("Generated Flawed Reasoning (Echo Generation):\n")
+
+    flawed_reasoning = generate_echo_reasoning(
+        model, tokenizer, premise, incorrect_conclusion, device
+    )
+    print(flawed_reasoning)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This experiment integrates the core data synthesis idea from the LogicORM paper into the experimental-vqasynth repository. The SOURCE repository, LogicORM, introduces a novel 'echo generation' technique to create flawed reasoning chains. This is achieved by prompting a Large Language Model (LLM) with an incorrect conclusion and asking it to generate a step-by-step justification, leveraging the model's tendency to reflect assumptions in the prompt. These flawed chains are valuable as negative examples for training Outcome Reward Models (ORMs) or for Direct Preference Optimization (DPO).

This feature branch introduces a minimal, self-contained script that demonstrates this echo generation technique. Placed within a new `experiments/` directory, the script uses a base LLM to generate a fallacious Chain-of-Thought (CoT) based on a valid premise but a deliberately incorrect conclusion. This aligns with experimental-vqasynth's goal of improving model reasoning through synthetic data generation.

By isolating and implementing this specific data generation strategy, we create a testable component that can later be scaled up. The generated negative reasoning samples could be used to fine-tune a reward model to better distinguish between correct and incorrect logical steps, enhancing the overall robustness of reasoning systems developed within the experimental-vqasynth framework.


### Test Strategy
- Ensure you have an environment with Python and the required packages. You can install them with: `pip install torch transformers accelerate`.
- Navigate to the root of the repository.
- Run the experiment script using the command: `python experiments/logic-orm-echo-generation/run.py`.
- Observe the console output. The script will print the premise, the incorrect conclusion it's aiming for, and the LLM-generated flawed reasoning chain.


### Success Criteria
- The script executes without any errors.
- The script loads the specified language model and generates a text output.
- The generated output is a step-by-step reasoning chain that attempts to logically connect the premise to the provided incorrect conclusion, demonstrating the 'echo' effect.


**Labels:** experiment, data-synthesis

---
**Source:** https://github.com/RamyaKeerthy/LogicORM
**Evidence:**
- `src/data_generation.py`
- `README.md`

**Experiment metadata:**
- experiment_id: local-1756688486
- run_id: run-1
- paper_id: 2508.19903v1
